### PR TITLE
Darkkal/issue13

### DIFF
--- a/src/app/gallery/components/BulkActionBar.tsx
+++ b/src/app/gallery/components/BulkActionBar.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import React from 'react';
+import styles from '../page.module.css';
+
+interface BulkActionBarProps {
+    selectedCount: number;
+    onBulkDelete: (deleteFiles: boolean) => void;
+    deleting: boolean;
+}
+
+export default function BulkActionBar({
+    selectedCount,
+    onBulkDelete,
+    deleting
+}: BulkActionBarProps) {
+    if (selectedCount === 0) return null;
+
+    return (
+        <div className={styles.bulkActionBar}>
+            <span>{selectedCount} items selected</span>
+            <div className={styles.bulkActionButtons}>
+                <button
+                    className={styles.secondaryDeleteButton}
+                    onClick={() => onBulkDelete(false)}
+                    disabled={deleting}
+                >
+                    {deleting ? '...' : 'Delete from DB'}
+                </button>
+                <button
+                    className={styles.deleteButton}
+                    onClick={() => onBulkDelete(true)}
+                    disabled={deleting}
+                >
+                    {deleting ? 'Deleting...' : 'Delete from Disk & DB'}
+                </button>
+            </div>
+        </div>
+    );
+}

--- a/src/app/gallery/components/FilterBar.tsx
+++ b/src/app/gallery/components/FilterBar.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React from 'react';
+import { CheckSquare, Square } from 'lucide-react';
+import styles from '../page.module.css';
+
+interface FilterBarProps {
+    selectionMode: boolean;
+    setSelectionMode: (mode: boolean) => void;
+    onSelectAll: () => void;
+    searchQuery: string;
+    setSearchQuery: (query: string) => void;
+    sortBy: string;
+    setSortBy: (sort: string) => void;
+    columnCount: number;
+    setColumnCount: (count: number) => void;
+    onRefresh: () => void;
+}
+
+export default function FilterBar({
+    selectionMode,
+    setSelectionMode,
+    onSelectAll,
+    searchQuery,
+    setSearchQuery,
+    sortBy,
+    setSortBy,
+    columnCount,
+    setColumnCount,
+    onRefresh
+}: FilterBarProps) {
+    return (
+        <div className={styles.filterBar}>
+            <button
+                className={selectionMode ? styles.activeButton : styles.secondaryButton}
+                onClick={() => setSelectionMode(!selectionMode)}
+                title={selectionMode ? 'Cancel Selection' : 'Select Items'}
+                style={{ padding: '0.4rem', lineHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+            >
+                {selectionMode ? <CheckSquare size={20} /> : <Square size={20} />}
+            </button>
+
+            {selectionMode && (
+                <button
+                    className={styles.secondaryButton}
+                    onClick={onSelectAll}
+                    title="Select All"
+                >
+                    Select All
+                </button>
+            )}
+
+            <div className={styles.separator} />
+
+            <input
+                type="text"
+                placeholder="Search (e.g. source:pixiv, min_favs:100, tag)..."
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && onRefresh()}
+                className={styles.input}
+                style={{ flex: 2 }}
+            />
+            <select
+                value={sortBy}
+                onChange={e => setSortBy(e.target.value)}
+                className={styles.input}
+            >
+                <option value="created-desc">Imported: Newest First</option>
+                <option value="created-asc">Oldest First</option>
+                <option value="captured-desc">Content Date: Newest First</option>
+                <option value="captured-asc">Content Date: Oldest First</option>
+            </select>
+            <div className={styles.separator} />
+            <div className={styles.sliderContainer}>
+                <label htmlFor="columns" className={styles.label}>Columns: {columnCount}</label>
+                <input
+                    id="columns"
+                    type="range"
+                    min="1"
+                    max="10"
+                    value={columnCount}
+                    onChange={e => setColumnCount(parseInt(e.target.value))}
+                    className={styles.slider}
+                />
+            </div>
+        </div>
+    );
+}

--- a/src/app/gallery/components/GalleryItem.tsx
+++ b/src/app/gallery/components/GalleryItem.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import styles from '../page.module.css';
+import { GalleryGroup } from '@/types/gallery';
+
+interface GalleryItemProps {
+    row: GalleryGroup;
+    isSelected: boolean;
+    selectionMode: boolean;
+    onClick: () => void;
+}
+
+export default function GalleryItem({
+    row,
+    isSelected,
+    selectionMode,
+    onClick
+}: GalleryItemProps) {
+    const item = row.item;
+    const count = row.groupCount || 1;
+
+    return (
+        <div
+            className={`${styles.item} ${isSelected ? styles.selectedItem : ''}`}
+            onClick={onClick}
+        >
+            {selectionMode && (
+                <div className={styles.checkbox}>
+                    {isSelected ? '✓' : ''}
+                </div>
+            )}
+
+            {count > 1 && (
+                <div className={styles.countBadge} title={`${count} items`}>
+                    <span>❐</span> {count}
+                </div>
+            )}
+
+            {item.mediaType === 'video' ? (
+                <>
+                    <video
+                        src={item.filePath}
+                        className={styles.media}
+                        muted
+                        loop
+                        onMouseOver={async e => {
+                            try {
+                                await (e.currentTarget as HTMLVideoElement).play();
+                            } catch (err: unknown) {
+                                if (err instanceof Error && err.name !== 'AbortError') console.error(err);
+                            }
+                        }}
+                        onMouseOut={e => (e.currentTarget as HTMLVideoElement).pause()}
+                    />
+                    <div className={styles.videoBadge}>VIDEO</div>
+                </>
+            ) : (
+                <Image
+                    src={item.filePath}
+                    alt={row.post?.title || 'Media thumbnail'}
+                    className={styles.media}
+                    width={400}
+                    height={400}
+                    style={{ width: '100%', height: 'auto' }}
+                    unoptimized
+                    loading="lazy"
+                />
+            )}
+            {row.twitter && (
+                <div style={{ position: 'absolute', bottom: 0, background: 'rgba(0,0,0,0.6)', color: 'white', fontSize: '11px', width: '100%', padding: '4px', display: 'flex', justifyContent: 'space-between' }}>
+                    <span>❤️ {row.twitter.favoriteCount}</span>
+                    {row.user && <span>@{row.user.username}</span>}
+                </div>
+            )}
+        </div>
+    );
+}

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -5,48 +5,14 @@ import { deleteMediaItems } from '../actions';
 import Lightbox from '../../components/Lightbox';
 import MasonryGrid from '../../components/MasonryGrid';
 import styles from './page.module.css';
-import Image from 'next/image';
-import { CheckSquare, Square } from 'lucide-react';
 import { mergePixivMetadata, mergeTwitterMetadata, mergeGelbooruv02Metadata } from '@/lib/metadata';
-
-interface MediaItem {
-    id: number;
-    filePath: string;
-    mediaType: 'image' | 'video' | 'audio' | 'text';
-    capturedAt: Date | null;
-    createdAt: Date;
-    postId: number | null;
-}
-
-interface Post {
-    id: number;
-    extractorType: string;
-    jsonSourceId: string | null;
-    internalSourceId: number | null;
-    userId: string | null;
-    date: string | null;
-    title: string | null;
-    content: string | null;
-    url: string | null;
-    metadataPath: string | null;
-    createdAt: Date;
-}
-
-interface GalleryRow {
-    item: MediaItem;
-    post?: Post;
-    twitter?: any;
-    pixiv?: any;
-    gelbooru?: any;
-    user?: any;
-    pixivUser?: any;
-    source?: any;
-}
-
-interface GalleryGroup extends GalleryRow {
-    groupItems: GalleryRow[];
-    groupCount: number;
-}
+import { GalleryGroup } from '@/types/gallery';
+import { useSelection } from '@/hooks/useSelection';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useLightbox } from '@/hooks/useLightbox';
+import FilterBar from './components/FilterBar';
+import BulkActionBar from './components/BulkActionBar';
+import GalleryItem from './components/GalleryItem';
 
 export default function GalleryPageClient({ 
     initialItems, 
@@ -62,17 +28,35 @@ export default function GalleryPageClient({
     const [items, setItems] = useState<GalleryGroup[]>(initialItems);
     const [searchQuery, setSearchQuery] = useState(initialSearch);
     const [sortBy, setSortBy] = useState(initialSort);
-    const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
-    const [mediaIndex, setMediaIndex] = useState(0); 
     const [columnCount, setColumnCount] = useState(4);
-
-    // Selection state
-    const [selectionMode, setSelectionMode] = useState(false);
-    const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
     const [deleting, setDeleting] = useState(false);
-
     const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
     const [isLoading, setIsLoading] = useState(false);
+
+    // Shared Hooks
+    const debouncedSearch = useDebouncedValue(searchQuery, 1000);
+    const debouncedSort = useDebouncedValue(sortBy, 1000);
+    
+    const { 
+        selectionMode, 
+        setSelectionMode, 
+        selectedIds, 
+        toggleGroupSelection, 
+        selectAll, 
+        clearSelection,
+        selectedCount 
+    } = useSelection();
+
+    const {
+        selectedIndex,
+        mediaIndex,
+        open: openLightbox,
+        close: closeLightbox,
+        next: nextLightbox,
+        prev: prevLightbox,
+        setSelectedIndex,
+        setMediaIndex
+    } = useLightbox(items.length, (idx) => items[idx].groupItems.length);
 
     const loadItems = useCallback(async (isAppending = false) => {
         setIsLoading(true);
@@ -93,51 +77,25 @@ export default function GalleryPageClient({
         }
     }, [searchQuery, sortBy, nextCursor]);
 
-    // Handle search/sort changes
+    // Handle search/sort changes via debounced values
     useEffect(() => {
-        const timer = setTimeout(() => {
-            // Reset cursor and items when search or sort changes
-            setNextCursor(null);
-            loadItems(false);
-        }, 1000);
-
-        return () => clearTimeout(timer);
-    }, [searchQuery, sortBy]);
-
-
-    function toggleSelection(group: GalleryGroup) {
-        const groupIds = group.groupItems.map((i) => i.item.id);
-        const newSelected = new Set(selectedIds);
-
-        const isPrimarySelected = newSelected.has(group.item.id);
-
-        if (isPrimarySelected) {
-            groupIds.forEach((id: number) => newSelected.delete(id));
-        } else {
-            groupIds.forEach((id: number) => newSelected.add(id));
-        }
-        setSelectedIds(newSelected);
-    }
-
-    function selectAll() {
-        const allIds = items.flatMap(group => group.groupItems.map((i) => i.item.id));
-        setSelectedIds(new Set(allIds));
-    }
+        setNextCursor(null);
+        loadItems(false);
+    }, [debouncedSearch, debouncedSort]);
 
     async function handleBulkDelete(deleteFiles: boolean) {
-        if (selectedIds.size === 0) return;
+        if (selectedCount === 0) return;
 
         const message = deleteFiles
-            ? `Permanently delete ${selectedIds.size} files from disk and database?`
-            : `Delete ${selectedIds.size} records from the database? (Files stay on disk)`;
+            ? `Permanently delete ${selectedCount} files from disk and database?`
+            : `Delete ${selectedCount} records from the database? (Files stay on disk)`;
 
         if (!confirm(message)) return;
 
         setDeleting(true);
         try {
             await deleteMediaItems(Array.from(selectedIds), deleteFiles);
-            setSelectedIds(new Set());
-            setSelectionMode(false);
+            clearSelection();
             await loadItems();
         } catch (err) {
             alert("Failed to delete items: " + err);
@@ -164,159 +122,48 @@ export default function GalleryPageClient({
 
     return (
         <div className={styles.container}>
-            {selectionMode && selectedIds.size > 0 && (
-                <div className={styles.bulkActionBar}>
-                    <span>{selectedIds.size} items selected</span>
-                    <div className={styles.bulkActionButtons}>
-                        <button
-                            className={styles.secondaryDeleteButton}
-                            onClick={() => handleBulkDelete(false)}
-                            disabled={deleting}
-                        >
-                            {deleting ? '...' : 'Delete from DB'}
-                        </button>
-                        <button
-                            className={styles.deleteButton}
-                            onClick={() => handleBulkDelete(true)}
-                            disabled={deleting}
-                        >
-                            {deleting ? 'Deleting...' : 'Delete from Disk & DB'}
-                        </button>
-                    </div>
-                </div>
+            {selectionMode && (
+                <BulkActionBar 
+                    selectedCount={selectedCount} 
+                    onBulkDelete={handleBulkDelete} 
+                    deleting={deleting} 
+                />
             )}
 
-            <div className={styles.filterBar}>
-                <button
-                    className={selectionMode ? styles.activeButton : styles.secondaryButton}
-                    onClick={() => {
-                        setSelectionMode(!selectionMode);
-                        if (!selectionMode) setSelectedIds(new Set());
-                    }}
-                    title={selectionMode ? 'Cancel Selection' : 'Select Items'}
-                    style={{ padding: '0.4rem', lineHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
-                >
-                    {selectionMode ? <CheckSquare size={20} /> : <Square size={20} />}
-                </button>
-
-                {selectionMode && (
-                    <button
-                        className={styles.secondaryButton}
-                        onClick={selectAll}
-                        title="Select All"
-                    >
-                        Select All
-                    </button>
-                )}
-
-                <div className={styles.separator} />
-
-                <input
-                    type="text"
-                    placeholder="Search (e.g. source:pixiv, min_favs:100, tag)..."
-                    value={searchQuery}
-                    onChange={e => setSearchQuery(e.target.value)}
-                    onKeyDown={e => e.key === 'Enter' && loadItems()}
-                    className={styles.input}
-                    style={{ flex: 2 }}
-                />
-                <select
-                    value={sortBy}
-                    onChange={e => setSortBy(e.target.value)}
-                    className={styles.input}
-                >
-                    <option value="created-desc">Imported: Newest First</option>
-                    <option value="created-asc">Oldest First</option>
-                    <option value="captured-desc">Content Date: Newest First</option>
-                    <option value="captured-asc">Content Date: Oldest First</option>
-                </select>
-                <div className={styles.separator} />
-                <div className={styles.sliderContainer}>
-                    <label htmlFor="columns" className={styles.label}>Columns: {columnCount}</label>
-                    <input
-                        id="columns"
-                        type="range"
-                        min="1"
-                        max="10"
-                        value={columnCount}
-                        onChange={e => setColumnCount(parseInt(e.target.value))}
-                        className={styles.slider}
-                    />
-                </div>
-            </div>
+            <FilterBar 
+                selectionMode={selectionMode}
+                setSelectionMode={(mode) => {
+                    setSelectionMode(mode);
+                    if (!mode) clearSelection();
+                }}
+                onSelectAll={() => selectAll(items.flatMap(group => group.groupItems.map(i => i.item.id)))}
+                searchQuery={searchQuery}
+                setSearchQuery={setSearchQuery}
+                sortBy={sortBy}
+                setSortBy={setSortBy}
+                columnCount={columnCount}
+                setColumnCount={setColumnCount}
+                onRefresh={() => loadItems(false)}
+            />
 
             <MasonryGrid
                 items={items}
                 columnCount={columnCount}
-                renderItem={(row: GalleryGroup, index: number) => {
-                    const item = row.item;
-                    const isSelected = selectedIds.has(item.id);
-                    const count = row.groupCount || 1;
-
-                    return (
-                        <div
-                            key={item.id}
-                            className={`${styles.item} ${isSelected ? styles.selectedItem : ''}`}
-                            onClick={() => {
-                                if (selectionMode) {
-                                    toggleSelection(row);
-                                } else {
-                                    setSelectedIndex(index);
-                                    setMediaIndex(0);
-                                }
-                            }}
-                        >
-                            {selectionMode && (
-                                <div className={styles.checkbox}>
-                                    {isSelected ? '✓' : ''}
-                                </div>
-                            )}
-
-                            {count > 1 && (
-                                <div className={styles.countBadge} title={`${count} items`}>
-                                    <span>❐</span> {count}
-                                </div>
-                            )}
-
-                            {item.mediaType === 'video' ? (
-                                <>
-                                    <video
-                                        src={item.filePath}
-                                        className={styles.media}
-                                        muted
-                                        loop
-                                        onMouseOver={async e => {
-                                            try {
-                                                await (e.currentTarget as HTMLVideoElement).play();
-                                            } catch (err: unknown) {
-                                                if (err instanceof Error && err.name !== 'AbortError') console.error(err);
-                                            }
-                                        }}
-                                        onMouseOut={e => (e.currentTarget as HTMLVideoElement).pause()}
-                                    />
-                                    <div className={styles.videoBadge}>VIDEO</div>
-                                </>
-                            ) : (
-                                <Image
-                                    src={item.filePath}
-                                    alt={row.post?.title || 'Media thumbnail'}
-                                    className={styles.media}
-                                    width={400}
-                                    height={400}
-                                    style={{ width: '100%', height: 'auto' }}
-                                    unoptimized
-                                    loading="lazy"
-                                />
-                            )}
-                            {row.twitter && (
-                                <div style={{ position: 'absolute', bottom: 0, background: 'rgba(0,0,0,0.6)', color: 'white', fontSize: '11px', width: '100%', padding: '4px', display: 'flex', justifyContent: 'space-between' }}>
-                                    <span>❤️ {row.twitter.favoriteCount}</span>
-                                    {row.user && <span>@{row.user.username}</span>}
-                                </div>
-                            )}
-                        </div>
-                    )
-                }}
+                renderItem={(row: GalleryGroup, index: number) => (
+                    <GalleryItem 
+                        key={row.item.id}
+                        row={row}
+                        isSelected={row.groupItems.some(i => selectedIds.has(i.item.id))}
+                        selectionMode={selectionMode}
+                        onClick={() => {
+                            if (selectionMode) {
+                                toggleGroupSelection(row.groupItems.map(i => i.item.id), row.item.id);
+                            } else {
+                                openLightbox(index, 0);
+                            }
+                        }}
+                    />
+                )}
             />
 
             {nextCursor && (
@@ -347,24 +194,9 @@ export default function GalleryPageClient({
                         pixiv={currentItemRow.post?.extractorType === 'pixiv' ? mergePixivMetadata(currentItemRow.post, currentItemRow.pixiv) : undefined}
                         gelbooru={currentItemRow.post?.extractorType === 'gelbooruv02' ? mergeGelbooruv02Metadata(currentItemRow.post, currentItemRow.gelbooru) : undefined}
                         pixivUser={currentItemRow.post?.extractorType === 'pixiv' ? currentItemRow.pixivUser : undefined}
-                        onClose={() => setSelectedIndex(null)}
-                        onNext={() => {
-                            if (mediaIndex < currentGroup.groupItems.length - 1) {
-                                setMediaIndex(mediaIndex + 1);
-                            } else if (selectedIndex! < items.length - 1) {
-                                setSelectedIndex(selectedIndex! + 1);
-                                setMediaIndex(0);
-                            }
-                        }}
-                        onPrev={() => {
-                            if (mediaIndex > 0) {
-                                setMediaIndex(mediaIndex - 1);
-                            } else if (selectedIndex! > 0) {
-                                const prevGroup = items[selectedIndex! - 1];
-                                setSelectedIndex(selectedIndex! - 1);
-                                setMediaIndex(prevGroup.groupItems.length - 1);
-                            }
-                        }}
+                        onClose={closeLightbox}
+                        onNext={nextLightbox}
+                        onPrev={prevLightbox}
                         onDelete={handleDeleteItem}
                     />
                 )

--- a/src/app/sources/components/AddSourceForm.tsx
+++ b/src/app/sources/components/AddSourceForm.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import { Plus } from 'lucide-react';
+import styles from '../page.module.css';
+
+interface AddSourceFormProps {
+  newUrl: string;
+  setNewUrl: (url: string) => void;
+  newName: string;
+  setNewName: (name: string) => void;
+  loading: boolean;
+  onSubmit: (e: React.FormEvent) => void;
+}
+
+export default function AddSourceForm({
+  newUrl,
+  setNewUrl,
+  newName,
+  setNewName,
+  loading,
+  onSubmit
+}: AddSourceFormProps) {
+  return (
+    <form onSubmit={onSubmit} className={styles.addForm}>
+      <h3>Add Source</h3>
+      <div style={{ display: 'flex', gap: '0.5rem', flex: 1 }}>
+        <input
+          type="url"
+          className={styles.input}
+          placeholder=" https://..."
+          value={newUrl}
+          onChange={(e) => setNewUrl(e.target.value)}
+          required
+          style={{ flex: 2 }}
+        />
+        <input
+          type="text"
+          className={styles.input}
+          placeholder="Name (Optional)"
+          value={newName}
+          onChange={(e) => setNewName(e.target.value)}
+          style={{ flex: 1 }}
+        />
+      </div>
+      <button type="submit" className={styles.button} disabled={loading}>
+        <Plus size={18} />
+        {loading ? 'Adding...' : 'Add'}
+      </button>
+    </form>
+  );
+}

--- a/src/app/sources/components/ControlsBar.tsx
+++ b/src/app/sources/components/ControlsBar.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import React from 'react';
+import { Search, Trash2, LayoutGrid, List as ListIcon } from 'lucide-react';
+import styles from '../page.module.css';
+
+interface ControlsBarProps {
+  search: string;
+  setSearch: (s: string) => void;
+  sortBy: 'created' | 'name';
+  setSortBy: (s: 'created' | 'name') => void;
+  selectedCount: number;
+  onDeleteSelected: () => void;
+  viewMode: 'card' | 'table';
+  setViewMode: (m: 'card' | 'table') => void;
+}
+
+export default function ControlsBar({
+  search,
+  setSearch,
+  sortBy,
+  setSortBy,
+  selectedCount,
+  onDeleteSelected,
+  viewMode,
+  setViewMode
+}: ControlsBarProps) {
+  return (
+    <div className={styles.controlsBar}>
+      <div className={styles.leftControls}>
+        <div className={styles.searchWrapper}>
+          <Search className={styles.searchIcon} />
+          <input
+            type="text"
+            className={styles.searchInput}
+            placeholder="Search sources..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+
+        <select
+          className={styles.select}
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as 'created' | 'name')}
+        >
+          <option value="created">Recently Added</option>
+          <option value="name">Name (A-Z)</option>
+        </select>
+      </div>
+
+      <div className={styles.rightControls}>
+        {selectedCount > 0 && (
+          <button
+            className={styles.deleteButton}
+            onClick={onDeleteSelected}
+          >
+            <Trash2 size={18} />
+            Delete ({selectedCount})
+          </button>
+        )}
+
+        <div style={{ display: 'flex', gap: '0.5rem' }}>
+          <button
+            className={`${styles.actionButton} ${viewMode === 'card' ? styles.active : ''}`}
+            onClick={() => setViewMode('card')}
+            title="Grid View"
+          >
+            <LayoutGrid size={20} />
+          </button>
+          <button
+            className={`${styles.actionButton} ${viewMode === 'table' ? styles.active : ''}`}
+            onClick={() => setViewMode('table')}
+            title="List View"
+          >
+            <ListIcon size={20} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sources/components/SourceCard.tsx
+++ b/src/app/sources/components/SourceCard.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import React from 'react';
+import { Image as ImageIcon } from 'lucide-react';
+import type { Source } from '@/types/source';
+import styles from '../page.module.css';
+
+interface SourceCardProps {
+  source: Source;
+  isSelected: boolean;
+  onToggleSelection: () => void;
+}
+
+export default function SourceCard({
+  source,
+  isSelected,
+  onToggleSelection
+}: SourceCardProps) {
+  const displayTitle = source.name || source.url.replace(/^https?:\/\//, '');
+
+  return (
+    <div
+      className={`${styles.card} ${isSelected ? styles.selected : ''}`}
+      onClick={onToggleSelection}
+    >
+      <div
+        className={styles.cardBg}
+        style={{
+          backgroundImage: source.previewImage ? `url(${source.previewImage})` : 'none',
+          backgroundColor: source.previewImage ? 'transparent' : 'hsl(var(--muted))'
+        }}
+      />
+      {!source.previewImage && (
+        <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'hsl(var(--muted-foreground))' }}>
+          <ImageIcon size={48} opacity={0.2} />
+        </div>
+      )}
+
+      <div className={styles.cardOverlay}>
+        <div className={styles.cardContent}>
+          <div className={styles.cardTitle} title={source.url}>{displayTitle}</div>
+          <div className={styles.cardMeta}>
+            <span className={styles.badge}>{source.extractorType}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.checkboxOverlay}>
+        <input
+          type="checkbox"
+          checked={isSelected}
+          readOnly
+          className={styles.checkbox}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/app/sources/components/SourceTableRow.tsx
+++ b/src/app/sources/components/SourceTableRow.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import React from 'react';
+import { Image as ImageIcon, Edit2, Check, X } from 'lucide-react';
+import type { Source } from '@/types/source';
+import styles from '../page.module.css';
+
+interface SourceTableRowProps {
+  source: Source;
+  isSelected: boolean;
+  isEditing: boolean;
+  editForm: { url: string; name: string };
+  onEditFormChange: (updates: Partial<{ url: string; name: string }>) => void;
+  onToggleSelection: () => void;
+  onStartEditing: () => void;
+  onCancelEditing: () => void;
+  onSaveEdit: () => void;
+}
+
+export default function SourceTableRow({
+  source,
+  isSelected,
+  isEditing,
+  editForm,
+  onEditFormChange,
+  onToggleSelection,
+  onStartEditing,
+  onCancelEditing,
+  onSaveEdit
+}: SourceTableRowProps) {
+  const displayTitle = source.name || source.url;
+
+  return (
+    <tr
+      className={`${styles.tableRow} ${isSelected ? styles.selected : ''}`}
+      onClick={(e) => {
+        // Don't select if clicking specific specific controls
+        if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'BUTTON' || (e.target as HTMLElement).closest('button')) return;
+        if (!isEditing) onToggleSelection();
+      }}
+    >
+      <td>
+        <input
+          type="checkbox"
+          checked={isSelected}
+          readOnly
+          className={styles.checkbox}
+          disabled={isEditing}
+        />
+      </td>
+      <td>
+        {source.previewImage ? (
+          <img
+            src={source.previewImage}
+            alt=""
+            className={styles.thumbnail}
+          />
+        ) : (
+          <div className={styles.placeholderThumb}>
+            <ImageIcon size={16} />
+          </div>
+        )}
+      </td>
+      <td>
+        {isEditing ? (
+          <div style={{ display: 'flex', gap: '4px' }}>
+            <button className={styles.iconButton} onClick={(e) => { e.stopPropagation(); onSaveEdit(); }} title="Save">
+              <Check size={16} className="text-green-500" />
+            </button>
+            <button className={styles.iconButton} onClick={(e) => { e.stopPropagation(); onCancelEditing(); }} title="Cancel">
+              <X size={16} className="text-red-500" />
+            </button>
+          </div>
+        ) : (
+          <button
+            className={styles.iconButton}
+            onClick={(e) => {
+              e.stopPropagation();
+              onStartEditing();
+            }}
+            title="Edit"
+          >
+            <Edit2 size={16} />
+          </button>
+        )}
+      </td>
+      <td>
+        {isEditing ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+            <input
+              className={styles.input}
+              style={{ padding: '4px 8px', fontSize: '0.9rem' }}
+              value={editForm.name}
+              onChange={e => onEditFormChange({ name: e.target.value })}
+              placeholder="Name"
+            />
+            <input
+              className={styles.input}
+              style={{ padding: '4px 8px', fontSize: '0.8rem' }}
+              value={editForm.url}
+              onChange={e => onEditFormChange({ url: e.target.value })}
+              placeholder="URL"
+            />
+          </div>
+        ) : (
+          <>
+            <div style={{ fontWeight: 500 }}>{displayTitle}</div>
+            <div style={{ fontSize: '0.8rem', color: 'hsl(var(--muted-foreground))' }}>{source.url}</div>
+          </>
+        )}
+      </td>
+      <td>
+        <span className={styles.badge} style={{ color: 'hsl(var(--foreground))', border: '1px solid hsl(var(--border))' }}>
+          {source.extractorType}
+        </span>
+      </td>
+      <td>
+        {new Date(source.createdAt).toLocaleDateString()}
+      </td>
+    </tr>
+  );
+}

--- a/src/app/sources/page-client.tsx
+++ b/src/app/sources/page-client.tsx
@@ -1,28 +1,14 @@
 'use client';
 
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import { addSource, deleteSource, updateSource } from '../actions';
 import styles from './page.module.css';
-import {
-  LayoutGrid,
-  List as ListIcon,
-  Search,
-  Trash2,
-  Plus,
-  Image as ImageIcon,
-  Edit2,
-  Check,
-  X
-} from 'lucide-react';
-
-type Source = {
-  id: number;
-  url: string;
-  name?: string;
-  extractorType?: string;
-  createdAt: string | Date;
-  previewImage?: string;
-};
+import { useSelection } from '@/hooks/useSelection';
+import type { Source } from '@/types/source';
+import AddSourceForm from './components/AddSourceForm';
+import ControlsBar from './components/ControlsBar';
+import SourceCard from './components/SourceCard';
+import SourceTableRow from './components/SourceTableRow';
 
 export default function SourcesPageClient({ initialSources }: { initialSources: Source[] }) {
   const [sources, setSources] = useState<Source[]>(initialSources);
@@ -32,11 +18,17 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
   const [viewMode, setViewMode] = useState<'card' | 'table'>('card');
   const [sortBy, setSortBy] = useState<'created' | 'name'>('created');
   const [search, setSearch] = useState('');
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set());
 
   // Edit State
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editForm, setEditForm] = useState<{ url: string; name: string }>({ url: '', name: '' });
+
+  const {
+    selectedIds,
+    toggleSelection,
+    selectAll,
+    selectedCount
+  } = useSelection();
 
   async function loadSources() {
     const res = await fetch('/api/sources');
@@ -49,7 +41,7 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
     if (!newUrl) return;
 
     setLoading(true);
-    await addSource(newUrl, newName); // Pass optional name
+    await addSource(newUrl, newName);
     setNewUrl('');
     setNewName('');
     const data = await loadSources();
@@ -58,15 +50,14 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
   }
 
   async function handleDeleteSelected() {
-    if (selectedIds.size === 0) return;
-    if (!confirm(`Are you sure you want to delete ${selectedIds.size} sources?`)) return;
+    if (selectedCount === 0) return;
+    if (!confirm(`Are you sure you want to delete ${selectedCount} sources?`)) return;
 
     const ids = Array.from(selectedIds);
     for (const id of ids) {
       await deleteSource(id);
     }
 
-    setSelectedIds(new Set());
     const data = await loadSources();
     setSources(data);
   }
@@ -83,32 +74,11 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
   }
 
   async function saveEdit(id: number) {
-    // Optimistic update
     setSources(prev => prev.map(s => s.id === id ? { ...s, url: editForm.url, name: editForm.name } : s));
-
     await updateSource(id, { url: editForm.url, name: editForm.name });
     setEditingId(null);
-    const data = await loadSources(); // Refresh to confirm
+    const data = await loadSources();
     setSources(data);
-  }
-
-  function toggleSelection(id: number) {
-    if (editingId === id) return; // Don't select if editing
-    const newSelected = new Set(selectedIds);
-    if (newSelected.has(id)) {
-      newSelected.delete(id);
-    } else {
-      newSelected.add(id);
-    }
-    setSelectedIds(newSelected);
-  }
-
-  function selectAll(filteredIds: number[]) {
-    if (selectedIds.size === filteredIds.length) {
-      setSelectedIds(new Set());
-    } else {
-      setSelectedIds(new Set(filteredIds));
-    }
   }
 
   const filteredAndSortedSources = useMemo(() => {
@@ -127,7 +97,6 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
       if (sortBy === 'name') {
         return (a.name || a.url).localeCompare(b.name || b.url);
       } else {
-        // Created desc
         return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
       }
     });
@@ -137,134 +106,36 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
 
   return (
     <div className={styles.container}>
-      {/* Add Source Form */}
-      <form onSubmit={handleAdd} className={styles.addForm}>
-        <h3>Add Source</h3>
-        <div style={{ display: 'flex', gap: '0.5rem', flex: 1 }}>
-          <input
-            type="url"
-            className={styles.input}
-            placeholder=" https://..."
-            value={newUrl}
-            onChange={(e) => setNewUrl(e.target.value)}
-            required
-            style={{ flex: 2 }}
-          />
-          <input
-            type="text"
-            className={styles.input}
-            placeholder="Name (Optional)"
-            value={newName}
-            onChange={(e) => setNewName(e.target.value)}
-            style={{ flex: 1 }}
-          />
-        </div>
-        <button type="submit" className={styles.button} disabled={loading}>
-          <Plus size={18} />
-          {loading ? 'Adding...' : 'Add'}
-        </button>
-      </form>
+      <AddSourceForm
+        newUrl={newUrl}
+        setNewUrl={setNewUrl}
+        newName={newName}
+        setNewName={setNewName}
+        loading={loading}
+        onSubmit={handleAdd}
+      />
 
-      {/* Controls */}
-      <div className={styles.controlsBar}>
-        <div className={styles.leftControls}>
-          <div className={styles.searchWrapper}>
-            <Search className={styles.searchIcon} />
-            <input
-              type="text"
-              className={styles.searchInput}
-              placeholder="Search sources..."
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-            />
-          </div>
+      <ControlsBar
+        search={search}
+        setSearch={setSearch}
+        sortBy={sortBy}
+        setSortBy={setSortBy}
+        selectedCount={selectedCount}
+        onDeleteSelected={handleDeleteSelected}
+        viewMode={viewMode}
+        setViewMode={setViewMode}
+      />
 
-          <select
-            className={styles.select}
-            value={sortBy}
-            onChange={(e) => setSortBy(e.target.value as 'created' | 'name')}
-          >
-            <option value="created">Recently Added</option>
-            <option value="name">Name (A-Z)</option>
-          </select>
-        </div>
-
-        <div className={styles.rightControls}>
-          {selectedIds.size > 0 && (
-            <button
-              className={styles.deleteButton}
-              onClick={handleDeleteSelected}
-            >
-              <Trash2 size={18} />
-              Delete ({selectedIds.size})
-            </button>
-          )}
-
-          <div style={{ display: 'flex', gap: '0.5rem' }}>
-            <button
-              className={`${styles.actionButton} ${viewMode === 'card' ? styles.active : ''}`}
-              onClick={() => setViewMode('card')}
-              title="Grid View"
-            >
-              <LayoutGrid size={20} />
-            </button>
-            <button
-              className={`${styles.actionButton} ${viewMode === 'table' ? styles.active : ''}`}
-              onClick={() => setViewMode('table')}
-              title="List View"
-            >
-              <ListIcon size={20} />
-            </button>
-          </div>
-        </div>
-      </div>
-
-      {/* List Area */}
       {viewMode === 'card' ? (
         <div className={styles.grid}>
-          {filteredAndSortedSources.map(source => {
-            const isSelected = selectedIds.has(source.id);
-            const displayTitle = source.name || source.url.replace(/^https?:\/\//, '');
-
-            return (
-              <div
-                key={source.id}
-                className={`${styles.card} ${isSelected ? styles.selected : ''}`}
-                onClick={() => toggleSelection(source.id)}
-              >
-                <div
-                  className={styles.cardBg}
-                  style={{
-                    backgroundImage: source.previewImage ? `url(${source.previewImage})` : 'none',
-                    backgroundColor: source.previewImage ? 'transparent' : 'hsl(var(--muted))'
-                  }}
-                />
-                {!source.previewImage && (
-                  <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'hsl(var(--muted-foreground))' }}>
-                    <ImageIcon size={48} opacity={0.2} />
-                  </div>
-                )}
-
-                <div className={styles.cardOverlay}>
-                  <div className={styles.cardContent}>
-                    <div className={styles.cardTitle} title={source.url}>{displayTitle}</div>
-                    <div className={styles.cardMeta}>
-                      <span className={styles.badge}>{source.extractorType}</span>
-                    </div>
-                  </div>
-                </div>
-
-                <div className={styles.checkboxOverlay}>
-                  <input
-                    type="checkbox"
-                    checked={isSelected}
-                    readOnly
-                    className={styles.checkbox}
-                  />
-                </div>
-              </div>
-            );
-          })}
+          {filteredAndSortedSources.map(source => (
+            <SourceCard
+              key={source.id}
+              source={source}
+              isSelected={selectedIds.has(source.id)}
+              onToggleSelection={() => toggleSelection(source.id)}
+            />
+          ))}
         </div>
       ) : (
         <div className={styles.tableContainer}>
@@ -275,7 +146,7 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
                   <input
                     type="checkbox"
                     className={styles.checkbox}
-                    checked={filteredAndSortedSources.length > 0 && selectedIds.size === filteredAndSortedSources.length}
+                    checked={filteredAndSortedSources.length > 0 && selectedCount === filteredAndSortedSources.length}
                     onChange={() => selectAll(filteredAndSortedSources.map(s => s.id))}
                   />
                 </th>
@@ -287,102 +158,20 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
               </tr>
             </thead>
             <tbody>
-              {filteredAndSortedSources.map(source => {
-                const isSelected = selectedIds.has(source.id);
-                const displayTitle = source.name || source.url;
-                const isEditing = editingId === source.id;
-
-                return (
-                  <tr
-                    key={source.id}
-                    className={`${styles.tableRow} ${isSelected ? styles.selected : ''}`}
-                    onClick={(e) => {
-                      // Don't select if clicking specific specific controls
-                      if ((e.target as HTMLElement).tagName === 'INPUT' || (e.target as HTMLElement).tagName === 'BUTTON') return;
-                      if (!isEditing) toggleSelection(source.id);
-                    }}
-                  >
-                    <td>
-                      <input
-                        type="checkbox"
-                        checked={isSelected}
-                        readOnly
-                        className={styles.checkbox}
-                        disabled={isEditing}
-                      />
-                    </td>
-                    <td>
-                      {source.previewImage ? (
-                        <img
-                          src={source.previewImage}
-                          alt=""
-                          className={styles.thumbnail}
-                        />
-                      ) : (
-                        <div className={styles.placeholderThumb}>
-                          <ImageIcon size={16} />
-                        </div>
-                      )}
-                    </td>
-                    <td>
-                      {isEditing ? (
-                        <div style={{ display: 'flex', gap: '4px' }}>
-                          <button className={styles.iconButton} onClick={() => saveEdit(source.id)} title="Save">
-                            <Check size={16} className="text-green-500" />
-                          </button>
-                          <button className={styles.iconButton} onClick={cancelEditing} title="Cancel">
-                            <X size={16} className="text-red-500" />
-                          </button>
-                        </div>
-                      ) : (
-                        <button
-                          className={styles.iconButton}
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            startEditing(source);
-                          }}
-                          title="Edit"
-                        >
-                          <Edit2 size={16} />
-                        </button>
-                      )}
-                    </td>
-                    <td>
-                      {isEditing ? (
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
-                          <input
-                            className={styles.input}
-                            style={{ padding: '4px 8px', fontSize: '0.9rem' }}
-                            value={editForm.name}
-                            onChange={e => setEditForm(prev => ({ ...prev, name: e.target.value }))}
-                            placeholder="Name"
-                          />
-                          <input
-                            className={styles.input}
-                            style={{ padding: '4px 8px', fontSize: '0.8rem' }}
-                            value={editForm.url}
-                            onChange={e => setEditForm(prev => ({ ...prev, url: e.target.value }))}
-                            placeholder="URL"
-                          />
-                        </div>
-                      ) : (
-                        <>
-                          <div style={{ fontWeight: 500 }}>{displayTitle}</div>
-                          <div style={{ fontSize: '0.8rem', color: 'hsl(var(--muted-foreground))' }}>{source.url}</div>
-                        </>
-                      )}
-                    </td>
-                    <td>
-                      <span className={styles.badge} style={{ color: 'hsl(var(--foreground))', border: '1px solid hsl(var(--border))' }}>
-                        {source.extractorType}
-                      </span>
-                    </td>
-                    <td>
-                      {new Date(source.createdAt).toLocaleDateString()}
-                    </td>
-                  </tr>
-                );
-              })}
+              {filteredAndSortedSources.map(source => (
+                <SourceTableRow
+                  key={source.id}
+                  source={source}
+                  isSelected={selectedIds.has(source.id)}
+                  isEditing={editingId === source.id}
+                  editForm={editForm}
+                  onEditFormChange={(updates) => setEditForm(prev => ({ ...prev, ...updates }))}
+                  onToggleSelection={() => toggleSelection(source.id)}
+                  onStartEditing={() => startEditing(source)}
+                  onCancelEditing={cancelEditing}
+                  onSaveEdit={() => saveEdit(source.id)}
+                />
+              ))}
             </tbody>
           </table>
         </div>

--- a/src/app/timeline/components/FilterBar.tsx
+++ b/src/app/timeline/components/FilterBar.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React from 'react';
+import styles from '../page.module.css';
+
+interface FilterBarProps {
+    searchQuery: string;
+    setSearchQuery: (query: string) => void;
+    sortBy: string;
+    setSortBy: (sort: string) => void;
+}
+
+export default function FilterBar({
+    searchQuery,
+    setSearchQuery,
+    sortBy,
+    setSortBy
+}: FilterBarProps) {
+    return (
+        <div className={styles.filterBar}>
+            <input
+                type="text"
+                placeholder="Search timeline (e.g. source:twitter)..."
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                className={styles.input}
+                style={{ flex: 1 }}
+            />
+            <div className={styles.separator} />
+            <select
+                value={sortBy}
+                onChange={e => setSortBy(e.target.value)}
+                className={styles.input}
+            >
+                <option value="created-desc">Imported: Newest First</option>
+                <option value="created-asc">Oldest First</option>
+                <option value="captured-desc">Content Date: Newest First</option>
+                <option value="captured-asc">Content Date: Oldest First</option>
+            </select>
+        </div>
+    );
+}

--- a/src/app/timeline/components/PostCard.tsx
+++ b/src/app/timeline/components/PostCard.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import React from 'react';
+import Image from 'next/image';
+import type { TimelinePost } from '@/lib/db/repositories/posts';
+import styles from '../page.module.css';
+
+interface PostCardProps {
+    post: TimelinePost;
+    postIndex: number;
+    onMediaClick: (postIndex: number, mediaIndex: number, e: React.MouseEvent) => void;
+}
+
+export default function PostCard({
+    post,
+    postIndex,
+    onMediaClick
+}: PostCardProps) {
+    return (
+        <article className={styles.postCard}>
+            {/* Header: Avatar, Name, Date */}
+            <div className={styles.postHeader}>
+                {post.author?.avatar ? (
+                    <Image src={post.author.avatar} alt={post.author.name || 'User'} width={40} height={40} className={styles.avatar} unoptimized />
+                ) : (
+                    <div className={styles.avatarPlaceholder} />
+                )}
+                <div className={styles.postMeta}>
+                    <div className={styles.authorRow}>
+                        <span className={styles.authorName}>{post.author?.name || 'Unknown'}</span>
+                        {post.author?.handle && <span className={styles.authorHandle}>@{post.author.handle}</span>}
+                    </div>
+                    <div className={styles.dateRow}>
+                        <span className={styles.date}>
+                            {new Date(post.date).toLocaleString()}
+                        </span>
+                        {post.type !== 'other' && (
+                            <span className={`${styles.badge} ${styles[post.type]}`}>
+                                {post.type}
+                            </span>
+                        )}
+                    </div>
+                </div>
+                {post.sourceUrl && (
+                    <a href={post.sourceUrl} target="_blank" rel="noopener noreferrer" className={styles.sourceLink}>
+                        ↗
+                    </a>
+                )}
+            </div>
+
+            {/* Content: Text */}
+            {post.content && (
+                <div
+                    className={styles.postContent}
+                    onClick={(e) => {
+                        const textMediaIndex = post.mediaItems.findIndex(m => m.type === 'text');
+                        if (textMediaIndex !== -1) {
+                            onMediaClick(postIndex, textMediaIndex, e);
+                        }
+                    }}
+                    style={{ cursor: post.mediaItems.some(m => m.type === 'text') ? 'pointer' : 'default' }}
+                >
+                    {post.content}
+                </div>
+            )}
+
+            {/* Media Grid */}
+            {post.mediaItems.filter(m => m.type !== 'text').length > 0 && (
+                <div className={`${styles.mediaGrid} ${styles[`grid-${Math.min(post.mediaItems.filter(m => m.type !== 'text').length, 4)}`]}`}>
+                    {post.mediaItems.map((media, originalIndex) => {
+                        if (media.type === 'text') return null;
+                        return (
+                            <div
+                                key={media.id}
+                                className={styles.mediaItem}
+                                onClick={(e) => onMediaClick(postIndex, originalIndex, e)}
+                            >
+                                {media.type === 'video' ? (
+                                    <video src={media.url} controls className={styles.media} />
+                                ) : (
+                                    <img src={media.url} alt="" className={styles.media} loading="lazy" />
+                                )}
+                            </div>
+                        );
+                    })}
+                </div>
+            )}
+
+            {/* Stats Footer */}
+            {post.stats && (
+                <div className={styles.postFooter}>
+                    {post.stats.likes !== undefined && <span>♥ {post.stats.likes}</span>}
+                    {post.stats.retweets !== undefined && <span>RP {post.stats.retweets}</span>}
+                </div>
+            )}
+        </article>
+    );
+}

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -1,11 +1,14 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import Image from 'next/image';
 import type { TimelinePost } from '@/lib/db/repositories/posts';
 import Lightbox from '../../components/Lightbox';
 import styles from './page.module.css';
 import { mergePixivMetadata, mergeTwitterMetadata, mergeGelbooruv02Metadata } from '@/lib/metadata';
+import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { useLightbox } from '@/hooks/useLightbox';
+import FilterBar from './components/FilterBar';
+import PostCard from './components/PostCard';
 
 export default function TimelinePageClient({ 
     initialPosts, 
@@ -19,12 +22,23 @@ export default function TimelinePageClient({
     initialSort: string
 }) {
     const [posts, setPosts] = useState<TimelinePost[]>(initialPosts);
-    const [selectedIndex, setSelectedIndex] = useState<{ postIndex: number, mediaIndex: number } | null>(null);
-
     const [searchQuery, setSearchQuery] = useState(initialSearch);
     const [sortBy, setSortBy] = useState(initialSort);
     const [nextCursor, setNextCursor] = useState<string | null>(initialNextCursor);
     const [isLoading, setIsLoading] = useState(false);
+
+    // Shared Hooks
+    const debouncedSearch = useDebouncedValue(searchQuery, 1000);
+    const debouncedSort = useDebouncedValue(sortBy, 1000);
+
+    const {
+        selectedIndex,
+        mediaIndex,
+        open: openLightbox,
+        close: closeLightbox,
+        next: nextLightbox,
+        prev: prevLightbox,
+    } = useLightbox(posts.length, (idx) => posts[idx].mediaItems.length);
 
     const loadPosts = useCallback(async (isAppending = false) => {
         setIsLoading(true);
@@ -45,28 +59,18 @@ export default function TimelinePageClient({
         }
     }, [searchQuery, sortBy, nextCursor]);
 
+    // Handle search/sort changes via debounced values
     useEffect(() => {
-        const timer = setTimeout(() => {
-            setNextCursor(null);
-            loadPosts(false);
-        }, 1000);
-        return () => clearTimeout(timer);
-    }, [searchQuery, sortBy]);
-
-    const openLightbox = (postIndex: number, mediaIndex: number, e: React.MouseEvent) => {
-        e.stopPropagation();
-        setSelectedIndex({ postIndex, mediaIndex });
-    };
-
-    const closeLightbox = () => setSelectedIndex(null);
+        setNextCursor(null);
+        loadPosts(false);
+    }, [debouncedSearch, debouncedSort]);
 
     // Prepare Lightbox Data from current selection
     const getLightboxProps = () => {
-        if (!selectedIndex) return null;
-        const post = posts[selectedIndex.postIndex];
-        const media = post.mediaItems[selectedIndex.mediaIndex];
+        if (selectedIndex === null) return null;
+        const post = posts[selectedIndex];
+        const media = post.mediaItems[mediaIndex];
 
-        // Helper call adaptation
         const pixivInput = post.type === 'pixiv' ? {
             id: post.pixivMetadata?.dbId || 0,
             jsonSourceId: post.pixivMetadata?.illustId?.toString() || null,
@@ -128,108 +132,21 @@ export default function TimelinePageClient({
 
     return (
         <div className={styles.container}>
-
-            <div className={styles.filterBar}>
-                <input
-                    type="text"
-                    placeholder="Search timeline (e.g. source:twitter)..."
-                    value={searchQuery}
-                    onChange={e => setSearchQuery(e.target.value)}
-                    className={styles.input}
-                    style={{ flex: 1 }}
-                />
-                <div className={styles.separator} />
-                <select
-                    value={sortBy}
-                    onChange={e => setSortBy(e.target.value)}
-                    className={styles.input}
-                >
-                    <option value="created-desc">Imported: Newest First</option>
-                    <option value="created-asc">Oldest First</option>
-                    <option value="captured-desc">Content Date: Newest First</option>
-                    <option value="captured-asc">Content Date: Oldest First</option>
-                </select>
-            </div>
+            <FilterBar 
+                searchQuery={searchQuery}
+                setSearchQuery={setSearchQuery}
+                sortBy={sortBy}
+                setSortBy={setSortBy}
+            />
 
             <div className={styles.feed}>
                 {posts.map((post, postIdx) => (
-                    <article key={post.id} className={styles.postCard}>
-                        {/* Header: Avatar, Name, Date */}
-                        <div className={styles.postHeader}>
-                            {post.author?.avatar ? (
-                                <Image src={post.author.avatar} alt={post.author.name || 'User'} width={40} height={40} className={styles.avatar} unoptimized />
-                            ) : (
-                                <div className={styles.avatarPlaceholder} />
-                            )}
-                            <div className={styles.postMeta}>
-                                <div className={styles.authorRow}>
-                                    <span className={styles.authorName}>{post.author?.name || 'Unknown'}</span>
-                                    {post.author?.handle && <span className={styles.authorHandle}>@{post.author.handle}</span>}
-                                </div>
-                                <div className={styles.dateRow}>
-                                    <span className={styles.date}>
-                                        {new Date(post.date).toLocaleString()}
-                                    </span>
-                                    {post.type !== 'other' && (
-                                        <span className={`${styles.badge} ${styles[post.type]}`}>
-                                            {post.type}
-                                        </span>
-                                    )}
-                                </div>
-                            </div>
-                            {post.sourceUrl && (
-                                <a href={post.sourceUrl} target="_blank" rel="noopener noreferrer" className={styles.sourceLink}>
-                                    ↗
-                                </a>
-                            )}
-                        </div>
-
-                        {/* Content: Text */}
-                        {post.content && (
-                            <div
-                                className={styles.postContent}
-                                onClick={(e) => {
-                                    const textMediaIndex = post.mediaItems.findIndex(m => m.type === 'text');
-                                    if (textMediaIndex !== -1) {
-                                        openLightbox(postIdx, textMediaIndex, e);
-                                    }
-                                }}
-                                style={{ cursor: post.mediaItems.some(m => m.type === 'text') ? 'pointer' : 'default' }}
-                            >
-                                {post.content}
-                            </div>
-                        )}
-
-                        {/* Media Grid */}
-                        {post.mediaItems.filter(m => m.type !== 'text').length > 0 && (
-                            <div className={`${styles.mediaGrid} ${styles[`grid-${Math.min(post.mediaItems.filter(m => m.type !== 'text').length, 4)}`]}`}>
-                                {post.mediaItems.map((media, originalIndex) => {
-                                    if (media.type === 'text') return null;
-                                    return (
-                                        <div
-                                            key={media.id}
-                                            className={styles.mediaItem}
-                                            onClick={(e) => openLightbox(postIdx, originalIndex, e)}
-                                        >
-                                            {media.type === 'video' ? (
-                                                <video src={media.url} controls className={styles.media} />
-                                            ) : (
-                                                <img src={media.url} alt="" className={styles.media} loading="lazy" />
-                                            )}
-                                        </div>
-                                    );
-                                })}
-                            </div>
-                        )}
-
-                        {/* Stats Footer (Optional) */}
-                        {post.stats && (
-                            <div className={styles.postFooter}>
-                                {post.stats.likes !== undefined && <span>♥ {post.stats.likes}</span>}
-                                {post.stats.retweets !== undefined && <span>RP {post.stats.retweets}</span>}
-                            </div>
-                        )}
-                    </article>
+                    <PostCard 
+                        key={post.id}
+                        post={post}
+                        postIndex={postIdx}
+                        onMediaClick={openLightbox}
+                    />
                 ))}
 
                 {posts.length === 0 && <p className={styles.empty}>No posts found.</p>}
@@ -247,26 +164,12 @@ export default function TimelinePageClient({
                 </div>
             )}
 
-            {selectedIndex && lightboxProps && (
+            {selectedIndex !== null && lightboxProps && (
                 <Lightbox
                     {...lightboxProps}
                     onClose={closeLightbox}
-                    onNext={() => {
-                        const post = posts[selectedIndex.postIndex];
-                        if (selectedIndex.mediaIndex < post.mediaItems.length - 1) {
-                            setSelectedIndex({ ...selectedIndex, mediaIndex: selectedIndex.mediaIndex + 1 });
-                        } else if (selectedIndex.postIndex < posts.length - 1) {
-                            setSelectedIndex({ postIndex: selectedIndex.postIndex + 1, mediaIndex: 0 });
-                        }
-                    }}
-                    onPrev={() => {
-                        if (selectedIndex.mediaIndex > 0) {
-                            setSelectedIndex({ ...selectedIndex, mediaIndex: selectedIndex.mediaIndex - 1 });
-                        } else if (selectedIndex.postIndex > 0) {
-                            const prevPost = posts[selectedIndex.postIndex - 1];
-                            setSelectedIndex({ postIndex: selectedIndex.postIndex - 1, mediaIndex: prevPost.mediaItems.length - 1 });
-                        }
-                    }}
+                    onNext={nextLightbox}
+                    onPrev={prevLightbox}
                     onDelete={undefined}
                 />
             )}

--- a/src/hooks/useDebouncedValue.ts
+++ b/src/hooks/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export function useDebouncedValue<T>(value: T, delay: number = 1000): T {
+    const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setDebouncedValue(value);
+        }, delay);
+
+        return () => {
+            clearTimeout(timer);
+        };
+    }, [value, delay]);
+
+    return debouncedValue;
+}

--- a/src/hooks/useLightbox.ts
+++ b/src/hooks/useLightbox.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+export function useLightbox(itemsLength: number, getGroupLength?: (index: number) => number) {
+    const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+    const [mediaIndex, setMediaIndex] = useState(0);
+
+    const open = (index: number, mIndex: number = 0) => {
+        setSelectedIndex(index);
+        setMediaIndex(mIndex);
+    };
+
+    const close = () => {
+        setSelectedIndex(null);
+    };
+
+    const next = () => {
+        if (selectedIndex === null) return;
+        
+        const groupLength = getGroupLength ? getGroupLength(selectedIndex) : 1;
+        
+        if (mediaIndex < groupLength - 1) {
+            setMediaIndex(mediaIndex + 1);
+        } else if (selectedIndex < itemsLength - 1) {
+            setSelectedIndex(selectedIndex + 1);
+            setMediaIndex(0);
+        }
+    };
+
+    const prev = () => {
+        if (selectedIndex === null) return;
+        
+        if (mediaIndex > 0) {
+            setMediaIndex(mediaIndex - 1);
+        } else if (selectedIndex > 0) {
+            const prevIndex = selectedIndex - 1;
+            setSelectedIndex(prevIndex);
+            const prevGroupLength = getGroupLength ? getGroupLength(prevIndex) : 1;
+            setMediaIndex(prevGroupLength - 1);
+        }
+    };
+
+    return {
+        selectedIndex,
+        mediaIndex,
+        isOpen: selectedIndex !== null,
+        open,
+        close,
+        next,
+        prev,
+        setSelectedIndex,
+        setMediaIndex
+    };
+}

--- a/src/hooks/useSelection.ts
+++ b/src/hooks/useSelection.ts
@@ -1,0 +1,53 @@
+import { useState } from 'react';
+
+export function useSelection<T = number>() {
+    const [selectionMode, setSelectionMode] = useState(false);
+    const [selectedIds, setSelectedIds] = useState<Set<T>>(new Set());
+
+    const toggleSelection = (id: T) => {
+        const newSelected = new Set(selectedIds);
+        if (newSelected.has(id)) {
+            newSelected.delete(id);
+        } else {
+            newSelected.add(id);
+        }
+        setSelectedIds(newSelected);
+    };
+
+    const toggleGroupSelection = (ids: T[], primaryId: T) => {
+        const newSelected = new Set(selectedIds);
+        const isPrimarySelected = newSelected.has(primaryId);
+
+        if (isPrimarySelected) {
+            ids.forEach((id) => newSelected.delete(id));
+        } else {
+            ids.forEach((id) => newSelected.add(id));
+        }
+        setSelectedIds(newSelected);
+    };
+
+    const selectAll = (allIds: T[]) => {
+        if (selectedIds.size === allIds.length) {
+            setSelectedIds(new Set());
+        } else {
+            setSelectedIds(new Set(allIds));
+        }
+    };
+
+    const clearSelection = () => {
+        setSelectedIds(new Set());
+        setSelectionMode(false);
+    };
+
+    return {
+        selectionMode,
+        setSelectionMode,
+        selectedIds,
+        setSelectedIds,
+        toggleSelection,
+        toggleGroupSelection,
+        selectAll,
+        clearSelection,
+        selectedCount: selectedIds.size,
+    };
+}

--- a/src/types/gallery.ts
+++ b/src/types/gallery.ts
@@ -1,0 +1,44 @@
+export interface MediaItem {
+    id: number;
+    filePath: string;
+    mediaType: 'image' | 'video' | 'audio' | 'text';
+    capturedAt: Date | null;
+    createdAt: Date;
+    postId: number | null;
+}
+
+export interface Post {
+    id: number;
+    extractorType: string;
+    jsonSourceId: string | null;
+    internalSourceId: number | null;
+    userId: string | null;
+    date: string | null;
+    title: string | null;
+    content: string | null;
+    url: string | null;
+    metadataPath: string | null;
+    createdAt: Date;
+}
+
+export interface GalleryRow {
+    item: MediaItem;
+    post?: Post;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    twitter?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    pixiv?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    gelbooru?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    user?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    pixivUser?: any;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    source?: any;
+}
+
+export interface GalleryGroup extends GalleryRow {
+    groupItems: GalleryRow[];
+    groupCount: number;
+}

--- a/src/types/source.ts
+++ b/src/types/source.ts
@@ -1,0 +1,8 @@
+export interface Source {
+  id: number;
+  url: string;
+  name?: string;
+  extractorType?: string;
+  createdAt: string | Date;
+  previewImage?: string;
+}


### PR DESCRIPTION
# Extract Shared Hooks & Break Up Monolithic Pages (Issue #13)

Three client page components contain all UI logic, state management, and rendering in single files:
- [page-client.tsx](src/app/gallery/page-client.tsx) — **375 lines** (Gallery)
- [page-client.tsx](src/app/sources/page-client.tsx) — **399 lines** (Sources)
- [page-client.tsx](src/app/timeline/page-client.tsx) — **276 lines** (Timeline)

Duplicated logic across pages:
- **Selection logic** (`toggleSelection`, `selectAll`, `handleBulkDelete`) — Gallery & Sources
- **Search debouncing** — Gallery & Timeline (identical `useEffect` with `setTimeout` pattern)
- **Lightbox navigation** — Gallery & Timeline (next/prev with group/media index logic)

## Proposed Changes

The work is organized into 5 sequential phases. Each phase ends with a validation gate (build + targeted E2E tests) before the next phase begins.

---

### Phase 1: Extract Shared Hooks & Types

Create the shared foundation that subsequent phases will consume. No existing code is modified — this is purely additive.

#### [NEW] [types.ts](src/types/gallery.ts)

Extract inline interfaces from `gallery/page-client.tsx` into a shared types file:
- `MediaItem`, `Post`, `GalleryRow`, `GalleryGroup`

These are currently defined inline (lines 12–49 of gallery page-client) and would benefit from being importable by the new sub-components.

#### [NEW] [useSelection.ts](src/hooks/useSelection.ts)

Extract selection state management shared between Gallery and Sources.

```typescript
interface UseSelectionOptions {
  onClearCallback?: () => void; // e.g., exit selection mode
}

interface UseSelectionReturn<T = number> {
  selectedIds: Set<T>;
  selectionMode: boolean;
  setSelectionMode: (mode: boolean) => void;
  toggleSelection: (id: T) => void;
  toggleGroupSelection: (ids: T[]) => void; // Gallery uses group-based selection
  selectAll: (allIds: T[]) => void;
  clearSelection: () => void;
  selectedCount: number;
}
```

**Source logic being extracted:**
- Gallery [page-client.tsx:70-126](src/app/gallery/page-client.tsx#L70-L126) — `selectionMode`, `selectedIds`, `toggleSelection`, `selectAll`
- Sources [page-client.tsx:35-112](src/app/sources/page-client.tsx#L35-L112) — `selectedIds`, `toggleSelection`, `selectAll`

> [!NOTE]
> Gallery's `toggleSelection` works on groups (array of IDs), while Sources works on individual IDs. The hook will expose both `toggleSelection(id)` and `toggleGroupSelection(ids[])` to cover both cases.

#### [NEW] [useDebouncedSearch.ts](src/hooks/useDebouncedSearch.ts)

Extract the debounced search + sort pattern shared between Gallery and Timeline.

```typescript
interface UseDebouncedSearchOptions {
  initialSearch: string;
  initialSort: string;
  delay?: number;             // default 1000ms
  onSearchChange: () => void; // callback when debounce fires
}

interface UseDebouncedSearchReturn {
  searchQuery: string;
  setSearchQuery: (q: string) => void;
  sortBy: string;
  setSortBy: (s: string) => void;
}
```

**Source logic being extracted:**
- Gallery [page-client.tsx:97-105](src/app/gallery/page-client.tsx#L97-L105) — `useEffect` with `setTimeout`
- Timeline [page-client.tsx:48-54](src/app/timeline/page-client.tsx#L48-L54) — identical pattern

#### [NEW] [useLightbox.ts](src/hooks/useLightbox.ts)

Extract lightbox open/close/navigate state. Both Gallery and Timeline manage lightbox indexes inline.

```typescript
interface UseLightboxOptions {
  itemCount: number;
  getGroupSize: (index: number) => number; // for multi-media items
}

interface UseLightboxReturn {
  selectedIndex: number | null;
  mediaIndex: number;
  open: (itemIndex: number, mediaIndex?: number) => void;
  close: () => void;
  next: () => void;
  prev: () => void;
  isOpen: boolean;
}
```

**Source logic being extracted:**
- Gallery [page-client.tsx:65-66](src/app/gallery/page-client.tsx#L65-L66) + [page-client.tsx:351-367](src/app/gallery/page-client.tsx#L351-L367) — `selectedIndex` / `mediaIndex` + `onNext` / `onPrev`
- Timeline [page-client.tsx:22](src/app/timeline/page-client.tsx#L22) + [page-client.tsx:254-268](src/app/timeline/page-client.tsx#L254-L268) — `selectedIndex` object + navigation

**Validation Gate:**
- `npm run build` succeeds (new files are additive-only, no consumers yet)
- Optionally: a quick manual import sanity check

---

### Phase 2: Break Up Gallery Page

Refactor [gallery/page-client.tsx](src/app/gallery/page-client.tsx) (375 → ~80 lines) by extracting sub-components and consuming the Phase 1 hooks.

#### [NEW] `src/app/gallery/components/FilterBar.tsx`

Extract lines 189–246. Receives props:
- `selectionMode`, `setSelectionMode`, `selectAll`, `selectedCount`
- `searchQuery`, `setSearchQuery`, `loadItems`
- `sortBy`, `setSortBy`
- `columnCount`, `setColumnCount`

Co-locate styles from [page.module.css](src/app/gallery/page.module.css) — the filter bar styles stay in the existing CSS module and are imported from the parent. No new CSS file needed since CSS Modules are scoped by import.

> [!IMPORTANT]
> CSS Modules scope issue: Sub-components in `components/` importing `../page.module.css` will work, but class names are scoped to whichever file imports them. Since the parent's CSS module already defines these styles, we should keep the import path as `../page.module.css` so the class names hash the same way during build.

#### [NEW] `src/app/gallery/components/GalleryItem.tsx`

Extract lines 251–318 (the `renderItem` callback). Props:
- `row: GalleryGroup`, `index: number`
- `isSelected: boolean`, `selectionMode: boolean`
- `onClick: () => void`

This covers the media thumbnail (image/video), selection checkbox, count badge, and Twitter overlay.

#### [NEW] `src/app/gallery/components/BulkActionBar.tsx`

Extract lines 167–187. Props:
- `selectedCount: number`
- `onBulkDelete: (deleteFiles: boolean) => void`
- `deleting: boolean`

#### [MODIFY] [page-client.tsx](src/app/gallery/page-client.tsx)

- Remove inline interfaces → import from `@/types/gallery`
- Replace selection state with `useSelection()` hook
- Replace debounced search effect with `useDebouncedSearch()` hook
- Replace lightbox state with `useLightbox()` hook
- Replace inline JSX with `<FilterBar>`, `<GalleryItem>`, `<BulkActionBar>` components
- Keep `loadItems`, `handleBulkDelete`, `handleDeleteItem` in the page-client as they orchestrate API calls and state transitions

**Validation Gate:**
- `npm run build` succeeds
- `npx playwright test tests/gallery.spec.ts` — all 4 tests pass
- Manual browser check: gallery loads, selection works, lightbox navigates, load-more functions

---

### Phase 3: Break Up Timeline Page

Refactor [timeline/page-client.tsx](src/app/timeline/page-client.tsx) (276 → ~60 lines).

#### [NEW] `src/app/timeline/components/FilterBar.tsx`

Extract lines 132–152. Props:
- `searchQuery`, `setSearchQuery`
- `sortBy`, `setSortBy`

#### [NEW] `src/app/timeline/components/PostCard.tsx`

Extract lines 156–232 (the `<article>` element). Props:
- `post: TimelinePost`
- `onMediaClick: (mediaIndex: number, e: React.MouseEvent) => void`

This includes the header (avatar, author info, date, badge), content text, media grid, and stats footer.

#### [NEW] `src/app/timeline/components/PostMediaGrid.tsx`

Extract lines 204–222 (the media grid within a post card). Props:
- `mediaItems: TimelinePost['mediaItems']`
- `onItemClick: (originalIndex: number, e: React.MouseEvent) => void`

> [!NOTE]
> PostCard can internally compose PostMediaGrid, keeping PostCard as the public API. PostMediaGrid is only extracted if PostCard alone would still be too large (~80+ lines). We can decide during implementation.

#### [MODIFY] [page-client.tsx](src/app/timeline/page-client.tsx)

- Replace debounced search with `useDebouncedSearch()` hook
- Replace lightbox state with `useLightbox()` hook
- Replace inline JSX with `<FilterBar>`, `<PostCard>` components
- Keep `loadPosts`, `getLightboxProps` in page-client

**Validation Gate:**
- `npm run build` succeeds
- `npx playwright test tests/timeline.spec.ts` — all 5 tests pass
- Manual browser check: timeline loads, search works, lightbox opens/navigates, sort works

---

### Phase 4: Break Up Sources Page

Refactor [sources/page-client.tsx](src/app/sources/page-client.tsx) (399 → ~80 lines).

#### [NEW] `src/app/sources/components/AddSourceForm.tsx`

Extract lines 141–166. Props:
- `onAdd: (url: string, name: string) => Promise<void>`
- `loading: boolean`

Self-contained form with its own local state (`newUrl`, `newName`).

#### [NEW] `src/app/sources/components/ControlsBar.tsx`

Extract lines 169–220. Props:
- `search`, `setSearch`
- `sortBy`, `setSortBy`
- `selectedCount: number`, `onDeleteSelected: () => void`
- `viewMode`, `setViewMode`

#### [NEW] `src/app/sources/components/SourceCard.tsx`

Extract lines 225–266 (card view item). Props:
- `source: Source`
- `isSelected: boolean`
- `onToggleSelection: () => void`

#### [NEW] `src/app/sources/components/SourceTableRow.tsx`

Extract lines 290–384 (table row, including inline edit state). Props:
- `source: Source`
- `isSelected: boolean`
- `isEditing: boolean`
- `editForm`, `setEditForm`
- `onToggleSelection: () => void`
- `onStartEditing: () => void`
- `onSaveEdit: () => void`
- `onCancelEditing: () => void`

#### [MODIFY] [page-client.tsx](src/app/sources/page-client.tsx)

- Replace selection state with `useSelection()` hook
- Replace inline JSX with extracted sub-components
- Keep `loadSources`, `handleAdd`, `handleDeleteSelected`, edit handlers in page-client

**Validation Gate:**
- `npm run build` succeeds
- `npx playwright test tests/sources.spec.ts` — all 4 tests pass
- Manual browser check: card/table views work, selection, inline editing, add source

---

### Phase 5: Final Validation

Full-suite validation to ensure nothing is broken across all pages.

- `npx playwright test` — all test files pass
- Manual browser walkthrough of Gallery → Timeline → Sources

---

## Open Questions

> [!IMPORTANT]
> **CSS Module sharing strategy**: For the extracted sub-components, the plan is to import the parent's `page.module.css` from the components folder (e.g., `import styles from '../page.module.css'`). This keeps styles co-located with the page and avoids creating per-component CSS files for what are page-specific (not globally reusable) components. Does this approach work for you, or would you prefer a separate CSS module per component?

> [!NOTE]
> **PostMediaGrid extraction**: The `PostCard` for timeline may be self-contained enough (~70 lines) to not warrant further decomposition into `PostMediaGrid`. I'll assess during implementation and only extract if the component exceeds ~80 lines. Sound reasonable?

## Verification Plan

### Automated Tests
After each phase:
```bash
npm run build                             # Type/build check
npx playwright test tests/<page>.spec.ts  # Targeted E2E
```

After Phase 5 (final):
```bash
npx playwright test                       # Full suite
```

### Manual Verification
- Browser walkthrough in the debug container after each page refactor
- Verify: page renders, search/filter works, selection + bulk actions work, lightbox opens/navigates
