### PR TITLE
refactor: migrate inline styles to CSS modules

### DIFF
--- a/src/app/gallery/components/FilterBar.tsx
+++ b/src/app/gallery/components/FilterBar.tsx
@@ -35,7 +35,6 @@ export default function FilterBar({
                 className={selectionMode ? styles.activeButton : styles.secondaryButton}
                 onClick={() => setSelectionMode(!selectionMode)}
                 title={selectionMode ? 'Cancel Selection' : 'Select Items'}
-                style={{ padding: '0.4rem', lineHeight: 0, display: 'flex', alignItems: 'center', justifyContent: 'center' }}
             >
                 {selectionMode ? <CheckSquare size={20} /> : <Square size={20} />}
             </button>

--- a/src/app/gallery/components/GalleryItem.tsx
+++ b/src/app/gallery/components/GalleryItem.tsx
@@ -69,7 +69,7 @@ export default function GalleryItem({
                 />
             )}
             {row.twitter && (
-                <div style={{ position: 'absolute', bottom: 0, background: 'rgba(0,0,0,0.6)', color: 'white', fontSize: '11px', width: '100%', padding: '4px', display: 'flex', justifyContent: 'space-between' }}>
+                <div className={styles.twitterOverlay}>
                     <span>❤️ {row.twitter.favoriteCount}</span>
                     {row.user && <span>@{row.user.username}</span>}
                 </div>

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -171,8 +171,7 @@ export default function GalleryPageClient({
                     <button 
                         onClick={() => loadItems(true)} 
                         disabled={isLoading}
-                        className={styles.secondaryButton}
-                        style={{ margin: '2rem auto', display: 'block', padding: '0.8rem 2rem' }}
+                        className={`${styles.secondaryButton} ${styles.loadMoreButton}`}
                     >
                         {isLoading ? 'Loading...' : 'Load More'}
                     </button>

--- a/src/app/gallery/page.module.css
+++ b/src/app/gallery/page.module.css
@@ -32,7 +32,7 @@
 }
 
 .activeButton {
-    background: #3b82f6;
+    background: hsl(var(--color-info));
     color: hsl(var(--primary-foreground));
     border: none;
     padding: 0.5rem 1rem;
@@ -70,7 +70,7 @@
 }
 
 .selectedItem {
-    outline: 4px solid #3b82f6;
+    outline: 4px solid hsl(var(--color-info));
     outline-offset: -4px;
 }
 
@@ -81,7 +81,7 @@
     width: 24px;
     height: 24px;
     border-radius: 50%;
-    background: rgba(59, 130, 246, 0.9);
+    background: hsl(var(--color-info) / 0.9);
     color: white;
     display: flex;
     align-items: center;
@@ -163,7 +163,7 @@
 }
 
 .deleteButton {
-    background: #ef4444;
+    background: hsl(var(--color-danger));
     color: white;
     border: none;
     padding: 0.5rem 1rem;
@@ -174,7 +174,7 @@
 }
 
 .deleteButton:hover {
-    background: #dc2626;
+    background: hsl(var(--color-danger) / 0.85);
 }
 
 .deleteButton:disabled {
@@ -188,7 +188,7 @@
 }
 
 .secondaryDeleteButton {
-    background: #f59e0b;
+    background: hsl(var(--color-warning));
     color: white;
     border: none;
     padding: 0.5rem 1rem;
@@ -199,7 +199,7 @@
 }
 
 .secondaryDeleteButton:hover {
-    background: #d97706;
+    background: hsl(var(--color-warning) / 0.85);
 }
 
 .secondaryDeleteButton:disabled {
@@ -226,6 +226,10 @@
     color: hsl(var(--foreground));
 }
 
+.searchInput {
+    flex: 2;
+}
+
 .separator {
     width: 1px;
     height: 24px;
@@ -247,4 +251,22 @@
 
 .slider {
     cursor: pointer;
+}
+
+.loadMoreButton {
+    margin: 2rem auto;
+    display: block;
+    padding: 0.8rem 2rem !important;
+}
+
+.twitterOverlay {
+    position: absolute;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.6);
+    color: white;
+    font-size: 11px;
+    width: 100%;
+    padding: 4px;
+    display: flex;
+    justify-content: space-between;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,6 +38,13 @@
   --glass-background: rgba(9, 9, 11, 0.6);
   --glass-border: rgba(255, 255, 255, 0.08);
   --glass-blur: 12px;
+
+  /* Semantic Status Colors */
+  --color-success: 142 71% 45%;
+  --color-info: 217 91% 60%;
+  --color-danger: 0 84% 60%;
+  --color-warning: 38 92% 50%;
+  --color-muted-label: 215 16% 62%;
 }
 
 [data-theme='light'] {
@@ -71,6 +78,13 @@
 
   --glass-background: rgba(255, 255, 255, 0.6);
   --glass-border: rgba(0, 0, 0, 0.08);
+
+  /* Semantic Status Colors Override */
+  --color-success: 142 71% 45%;
+  --color-info: 217 91% 60%;
+  --color-danger: 0 72% 51%;
+  --color-warning: 38 92% 50%;
+  --color-muted-label: 215 20% 45%;
 }
 
 * {

--- a/src/app/library/page-client.tsx
+++ b/src/app/library/page-client.tsx
@@ -114,42 +114,42 @@ export default function LibraryPageClient({ initialScanStatus }: { initialScanSt
                     <div className={styles.scanStats}>
                         <div className={styles.statsRow}>
                             <div>
-                                <span style={{ color: '#94a3b8' }}>Status: </span>
+                                <span className={styles.mutedLabel}>Status: </span>
                                 <span className={`${styles.badge} ${styles[`status-${scanStatus.status}`] || ''}`}>
                                     {scanStatus.status}
                                 </span>
                             </div>
                             {scanStatus.status === 'running' && (
                                 <div>
-                                    <span style={{ color: '#94a3b8' }}>Processed: </span>
+                                    <span className={styles.mutedLabel}>Processed: </span>
                                     {scanStatus.filesProcessed} items
                                 </div>
                             )}
                             {scanStatus.status !== 'running' && (
                                 <>
                                     <div>
-                                        <span style={{ color: '#94a3b8' }}>Last Run: </span>
+                                        <span className={styles.mutedLabel}>Last Run: </span>
                                         {new Date(scanStatus.startTime).toLocaleString()}
                                     </div>
                                     {scanStatus.endTime && (
                                         <div>
-                                            <span style={{ color: '#94a3b8' }}>Duration: </span>
+                                            <span className={styles.mutedLabel}>Duration: </span>
                                             {formatDuration(scanStatus.startTime, scanStatus.endTime)}
                                         </div>
                                     )}
                                     <div>
-                                        <span style={{ color: '#94a3b8' }}>Results: </span>
-                                        <span style={{ color: '#4ade80' }}>+{scanStatus.filesAdded}</span>
+                                        <span className={styles.mutedLabel}>Results: </span>
+                                        <span className={styles.resultAdded}>+{scanStatus.filesAdded}</span>
                                         {' / '}
-                                        <span style={{ color: '#60a5fa' }}>~{scanStatus.filesUpdated}</span>
+                                        <span className={styles.resultUpdated}>~{scanStatus.filesUpdated}</span>
                                         {' / '}
-                                        <span style={{ color: '#f87171' }}>-{scanStatus.filesDeleted}</span>
+                                        <span className={styles.resultDeleted}>-{scanStatus.filesDeleted}</span>
                                     </div>
                                 </>
                             )}
                             {scanStatus.errors > 0 && (
                                 <div>
-                                    <span style={{ color: '#f87171' }}>{scanStatus.errors} errors</span>
+                                    <span className={styles.resultDeleted}>{scanStatus.errors} errors</span>
                                 </div>
                             )}
                         </div>
@@ -220,7 +220,7 @@ export default function LibraryPageClient({ initialScanStatus }: { initialScanSt
                         Purge Downloads
                     </button>
                 </div>
-                <p className={styles.dangerNote} style={{ marginTop: '1rem' }}>
+                <p className={styles.dangerNote}>
                     Database Purge stops all activities and wipes the DB. <br />
                     Purge Avatars deletes 'public/avatars'. <br />
                     Purge Downloads deletes 'public/downloads'.

--- a/src/app/library/page.module.css
+++ b/src/app/library/page.module.css
@@ -7,7 +7,7 @@
 .title {
   font-size: 2.5rem;
   font-weight: 700;
-  background: linear-gradient(to right, #ffffff, #94a3b8);
+  background: linear-gradient(to right, hsl(var(--foreground)), hsl(var(--color-muted-label)));
   background-clip: text;
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
@@ -104,8 +104,8 @@
 }
 
 .badge.status-completed {
-  background: #064e3b;
-  color: #6ee7b7;
+  background: hsl(var(--color-success) / 0.2);
+  color: hsl(var(--color-success));
 }
 
 .badge.status-stopped {
@@ -114,13 +114,13 @@
 }
 
 .badge.status-failed {
-  background: hsl(0 62.8% 30.6%);
-  color: #fca5a5;
+  background: hsl(var(--color-danger) / 0.2);
+  color: hsl(var(--color-danger) / 0.8);
 }
 
 .badge.status-running {
-  background: hsl(217 91% 20%);
-  color: #93c5fd;
+  background: hsl(var(--color-info) / 0.2);
+  color: hsl(var(--color-info) / 0.8);
 }
 
 /* Danger Zone */
@@ -130,7 +130,7 @@
 }
 
 .dangerTitle {
-  color: #ef4444 !important;
+  color: hsl(var(--color-danger)) !important;
 }
 
 .dangerActions {
@@ -141,7 +141,7 @@
 }
 
 .dangerButton {
-  background: #ef4444;
+  background: hsl(var(--color-danger));
   color: white;
   border: none;
   padding: 0.75rem 1.5rem;
@@ -152,7 +152,7 @@
 }
 
 .dangerButton:hover {
-  background: #dc2626;
+  background: hsl(var(--color-danger) / 0.85);
 }
 
 .dangerButton:disabled {
@@ -163,5 +163,21 @@
 .dangerNote {
   font-size: 0.875rem;
   color: hsl(var(--muted-foreground));
-  margin: 0;
+  margin: 1rem 0 0;
+}
+
+.mutedLabel {
+  color: hsl(var(--color-muted-label));
+}
+
+.resultAdded {
+  color: hsl(var(--color-success));
+}
+
+.resultUpdated {
+  color: hsl(var(--color-info));
+}
+
+.resultDeleted {
+  color: hsl(var(--color-danger));
 }

--- a/src/app/scrape/history-table.tsx
+++ b/src/app/scrape/history-table.tsx
@@ -83,11 +83,11 @@ export default function ScrapeHistoryTable({ initialHistory }: { initialHistory:
                         <th>Time</th>
                         <th>Duration</th>
                         <th>Status</th>
-                        <th style={{ textAlign: 'right' }}>Downloaded</th>
-                        <th style={{ textAlign: 'right' }}>Posts</th>
-                        <th style={{ textAlign: 'right' }}>Skipped</th>
-                        <th style={{ textAlign: 'right' }}>Size</th>
-                        <th style={{ textAlign: 'right' }}>Errors</th>
+                        <th className={styles.thRight}>Downloaded</th>
+                        <th className={styles.thRight}>Posts</th>
+                        <th className={styles.thRight}>Skipped</th>
+                        <th className={styles.thRight}>Size</th>
+                        <th className={styles.thRight}>Errors</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -100,36 +100,24 @@ export default function ScrapeHistoryTable({ initialHistory }: { initialHistory:
                                 {item.endTime ? (
                                     <span>{Math.round((new Date(item.endTime).getTime() - new Date(item.startTime).getTime()) / 1000)}s</span>
                                 ) : (
-                                    <span style={{ animation: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite', opacity: 0.7 }}>Running...</span>
+                                    <span className={styles.runningPulse}>Running...</span>
                                 )}
                             </td>
                             <td>
-                                <span className={styles.badge} style={{
-                                    backgroundColor:
-                                        item.status === 'completed' ? 'rgba(34, 197, 94, 0.1)' :
-                                            item.status === 'failed' ? 'rgba(239, 68, 68, 0.1)' :
-                                                item.status === 'running' ? 'rgba(59, 130, 246, 0.1)' : 'hsl(var(--muted))',
-                                    color:
-                                        item.status === 'completed' ? 'rgb(34, 197, 94)' :
-                                            item.status === 'failed' ? 'rgb(239, 68, 68)' :
-                                                item.status === 'running' ? 'rgb(59, 130, 246)' : 'hsl(var(--muted-foreground))',
-                                    border: '1px solid currentColor',
-                                    borderColor: 'currentColor',
-                                    opacity: 0.9
-                                }}>
+                                <span className={styles.badge} data-status={item.status}>
                                     {item.status}
                                 </span>
                             </td>
-                            <td style={{ textAlign: 'right' }}>{item.filesDownloaded}</td>
-                            <td style={{ textAlign: 'right' }}>{item.postsProcessed ?? 0}</td>
-                            <td style={{ textAlign: 'right' }}>{item.skippedCount ?? 0}</td>
-                            <td style={{ textAlign: 'right' }}>{formatBytes(item.bytesDownloaded || 0)}</td>
-                            <td style={{ textAlign: 'right', color: item.errorCount ? 'hsl(var(--destructive))' : 'inherit' }}>{item.errorCount}</td>
+                            <td className={styles.tdRight}>{item.filesDownloaded}</td>
+                            <td className={styles.tdRight}>{item.postsProcessed ?? 0}</td>
+                            <td className={styles.tdRight}>{item.skippedCount ?? 0}</td>
+                            <td className={styles.tdRight}>{formatBytes(item.bytesDownloaded || 0)}</td>
+                            <td className={`${styles.tdRight} ${item.errorCount ? styles.errorText : ''}`}>{item.errorCount}</td>
                         </tr>
                     ))}
                     {historyItems.length === 0 && (
                         <tr>
-                            <td colSpan={8} style={{ textAlign: 'center', padding: '3rem', color: 'hsl(var(--muted-foreground))' }}>
+                            <td colSpan={8} className={styles.emptyCell}>
                                 No history available.
                             </td>
                         </tr>

--- a/src/app/scrape/page.module.css
+++ b/src/app/scrape/page.module.css
@@ -99,6 +99,43 @@
     cursor: not-allowed;
 }
 
+.thRight, .tdRight {
+    text-align: right;
+}
+
+.runningPulse {
+    animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+    opacity: 0.7;
+}
+
+.badge[data-status="completed"] {
+    background: hsl(var(--color-success) / 0.1);
+    color: hsl(var(--color-success));
+    border: 1px solid currentColor;
+}
+
+.badge[data-status="failed"] {
+    background: hsl(var(--color-danger) / 0.1);
+    color: hsl(var(--color-danger));
+    border: 1px solid currentColor;
+}
+
+.badge[data-status="running"] {
+    background: hsl(var(--color-info) / 0.1);
+    color: hsl(var(--color-info));
+    border: 1px solid currentColor;
+}
+
+.errorText {
+    color: hsl(var(--destructive));
+}
+
+.emptyCell {
+    text-align: center;
+    padding: 3rem;
+    color: hsl(var(--muted-foreground));
+}
+
 /* Tabs Area */
 .tabsContainer {
     flex: 1;

--- a/src/app/sources/components/AddSourceForm.tsx
+++ b/src/app/sources/components/AddSourceForm.tsx
@@ -24,23 +24,21 @@ export default function AddSourceForm({
   return (
     <form onSubmit={onSubmit} className={styles.addForm}>
       <h3>Add Source</h3>
-      <div style={{ display: 'flex', gap: '0.5rem', flex: 1 }}>
+      <div className={styles.formInputRow}>
         <input
           type="url"
-          className={styles.input}
           placeholder=" https://..."
           value={newUrl}
           onChange={(e) => setNewUrl(e.target.value)}
           required
-          style={{ flex: 2 }}
+          className={`${styles.input} ${styles.inputWide}`}
         />
         <input
           type="text"
-          className={styles.input}
           placeholder="Name (Optional)"
           value={newName}
           onChange={(e) => setNewName(e.target.value)}
-          style={{ flex: 1 }}
+          className={styles.input}
         />
       </div>
       <button type="submit" className={styles.button} disabled={loading}>

--- a/src/app/sources/components/ControlsBar.tsx
+++ b/src/app/sources/components/ControlsBar.tsx
@@ -60,7 +60,7 @@ export default function ControlsBar({
           </button>
         )}
 
-        <div style={{ display: 'flex', gap: '0.5rem' }}>
+        <div className={styles.viewToggle}>
           <button
             className={`${styles.actionButton} ${viewMode === 'card' ? styles.active : ''}`}
             onClick={() => setViewMode('card')}

--- a/src/app/sources/components/SourceCard.tsx
+++ b/src/app/sources/components/SourceCard.tsx
@@ -27,11 +27,10 @@ export default function SourceCard({
         className={styles.cardBg}
         style={{
           backgroundImage: source.previewImage ? `url(${source.previewImage})` : 'none',
-          backgroundColor: source.previewImage ? 'transparent' : 'hsl(var(--muted))'
         }}
       />
       {!source.previewImage && (
-        <div style={{ position: 'absolute', inset: 0, display: 'flex', alignItems: 'center', justifyContent: 'center', color: 'hsl(var(--muted-foreground))' }}>
+        <div className={styles.placeholderIcon}>
           <ImageIcon size={48} opacity={0.2} />
         </div>
       )}

--- a/src/app/sources/components/SourceTableRow.tsx
+++ b/src/app/sources/components/SourceTableRow.tsx
@@ -63,12 +63,12 @@ export default function SourceTableRow({
       </td>
       <td>
         {isEditing ? (
-          <div style={{ display: 'flex', gap: '4px' }}>
+          <div className={styles.editActions}>
             <button className={styles.iconButton} onClick={(e) => { e.stopPropagation(); onSaveEdit(); }} title="Save">
-              <Check size={16} className="text-green-500" />
+              <Check size={16} className={styles.iconSuccess} />
             </button>
             <button className={styles.iconButton} onClick={(e) => { e.stopPropagation(); onCancelEditing(); }} title="Cancel">
-              <X size={16} className="text-red-500" />
+              <X size={16} className={styles.iconDanger} />
             </button>
           </div>
         ) : (
@@ -86,17 +86,15 @@ export default function SourceTableRow({
       </td>
       <td>
         {isEditing ? (
-          <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+          <div className={styles.editFields}>
             <input
-              className={styles.input}
-              style={{ padding: '4px 8px', fontSize: '0.9rem' }}
+              className={`${styles.input} ${styles.editInput}`}
               value={editForm.name}
               onChange={e => onEditFormChange({ name: e.target.value })}
               placeholder="Name"
             />
             <input
-              className={styles.input}
-              style={{ padding: '4px 8px', fontSize: '0.8rem' }}
+              className={`${styles.input} ${styles.editInputSmall}`}
               value={editForm.url}
               onChange={e => onEditFormChange({ url: e.target.value })}
               placeholder="URL"
@@ -104,13 +102,13 @@ export default function SourceTableRow({
           </div>
         ) : (
           <>
-            <div style={{ fontWeight: 500 }}>{displayTitle}</div>
-            <div style={{ fontSize: '0.8rem', color: 'hsl(var(--muted-foreground))' }}>{source.url}</div>
+            <div className={styles.sourceTitle}>{displayTitle}</div>
+            <div className={styles.sourceUrl}>{source.url}</div>
           </>
         )}
       </td>
       <td>
-        <span className={styles.badge} style={{ color: 'hsl(var(--foreground))', border: '1px solid hsl(var(--border))' }}>
+        <span className={`${styles.badge} ${styles.tableBadge}`}>
           {source.extractorType}
         </span>
       </td>

--- a/src/app/sources/page-client.tsx
+++ b/src/app/sources/page-client.tsx
@@ -142,7 +142,7 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
           <table className={styles.table}>
             <thead>
               <tr>
-                <th style={{ width: '40px' }}>
+                <th className={styles.thCheck}>
                   <input
                     type="checkbox"
                     className={styles.checkbox}
@@ -150,8 +150,8 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
                     onChange={() => selectAll(filteredAndSortedSources.map(s => s.id))}
                   />
                 </th>
-                <th style={{ width: '60px' }}>Preview</th>
-                <th style={{ width: '60px' }}></th>
+                <th className={styles.thThumb}>Preview</th>
+                <th className={styles.thActions}></th>
                 <th>Name / URL</th>
                 <th>Type</th>
                 <th>Created</th>
@@ -178,7 +178,7 @@ export default function SourcesPageClient({ initialSources }: { initialSources: 
       )}
 
       {filteredAndSortedSources.length === 0 && (
-        <div style={{ padding: '4rem', textAlign: 'center', color: 'hsl(var(--muted-foreground))' }}>
+        <div className={styles.emptyState}>
           No sources found.
         </div>
       )}

--- a/src/app/tags/page.module.css
+++ b/src/app/tags/page.module.css
@@ -78,3 +78,9 @@
     display: flex;
     justify-content: space-between;
 }
+
+.emptyState {
+    text-align: center;
+    padding: 40px;
+    color: hsl(var(--muted-foreground));
+}

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -63,7 +63,7 @@ export default async function TagsPage({ searchParams }: TagsPageProps) {
             </div>
 
             {tags.length === 0 && (
-                <div style={{ textAlign: 'center', padding: '40px', color: '#888' }}>
+                <div className={styles.emptyState}>
                     No tags found.
                 </div>
             )}

--- a/src/app/timeline/components/FilterBar.tsx
+++ b/src/app/timeline/components/FilterBar.tsx
@@ -23,8 +23,7 @@ export default function FilterBar({
                 placeholder="Search timeline (e.g. source:twitter)..."
                 value={searchQuery}
                 onChange={e => setSearchQuery(e.target.value)}
-                className={styles.input}
-                style={{ flex: 1 }}
+                className={`${styles.input} ${styles.searchInput}`}
             />
             <div className={styles.separator} />
             <select

--- a/src/components/Lightbox.module.css
+++ b/src/components/Lightbox.module.css
@@ -162,6 +162,10 @@
     text-align: center;
 }
 
+.statItemFull {
+    grid-column: 1 / -1;
+}
+
 .statValue {
     display: block;
     font-size: 1.1rem;
@@ -191,6 +195,10 @@
 .linkButton:hover {
     opacity: 0.9;
     transform: translateY(-1px);
+}
+
+.linkButton + .linkButton {
+    margin-top: 10px;
 }
 
 .controls {
@@ -224,12 +232,12 @@
 }
 
 .deleteDBButton:hover {
-    background: #f59e0b !important;
+    background: hsl(var(--color-warning)) !important;
     color: white !important;
 }
 
 .deleteDiskButton:hover {
-    background: #ef4444 !important;
+    background: hsl(var(--color-danger)) !important;
     color: white !important;
 }
 
@@ -311,4 +319,18 @@
     border-radius: var(--radius);
     overflow-y: auto;
     max-height: 80vh;
+}
+
+.tagsContainer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+}
+
+.tagChip {
+    background: rgba(255, 255, 255, 0.1);
+    padding: 2px 8px;
+    border-radius: 12px;
+    font-size: 12px;
+    color: hsl(var(--muted-foreground));
 }

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -284,7 +284,7 @@ export default function Lightbox({ item, tweet, user, pixiv, pixivUser, gelbooru
                         <h3 className={styles.sectionTitle}>Gelbooru Info</h3>
                         <div className={styles.statsGrid}>
                             {gelbooru.source && (
-                                <div className={styles.statItem} style={{ gridColumn: '1 / -1' }}>
+                                <div className={`${styles.statItem} ${styles.statItemFull}`}>
                                     {/* Assuming Link component is available or replace with <a> */}
                                     {/* <Link size={16} /> */}
                                     <a href={gelbooru.source || undefined} target="_blank" rel="noopener noreferrer" className={styles.link}>
@@ -300,7 +300,7 @@ export default function Lightbox({ item, tweet, user, pixiv, pixivUser, gelbooru
                             </div>
                             {gelbooru.rating && (
                                 <div className={styles.statItem}>
-                                    <span className={styles.badge} style={{ textTransform: 'uppercase' }}>
+                                    <span className={styles.badge}>
                                         {gelbooru.rating}
                                     </span>
                                     <span className={styles.statLabel}>Rating</span>
@@ -313,15 +313,9 @@ export default function Lightbox({ item, tweet, user, pixiv, pixivUser, gelbooru
                 {tags.length > 0 && (
                     <div className={styles.section}>
                         <h3 className={styles.sectionTitle}>Tags</h3>
-                        <div className={styles.tagsContainer} style={{ display: 'flex', flexWrap: 'wrap', gap: '4px' }}>
+                        <div className={styles.tagsContainer}>
                             {tags.map((tag, i) => (
-                                <span key={i} className={styles.tagChip} style={{
-                                    background: 'rgba(255,255,255,0.1)',
-                                    padding: '2px 8px',
-                                    borderRadius: '12px',
-                                    fontSize: '12px',
-                                    color: '#ccc'
-                                }}>
+                                <span key={i} className={styles.tagChip}>
                                     #{tag.name}
                                 </span>
                             ))}
@@ -333,7 +327,7 @@ export default function Lightbox({ item, tweet, user, pixiv, pixivUser, gelbooru
                     <div className={styles.section}>
                         <h3 className={styles.sectionTitle}>Source</h3>
                         {item.originalUrl && (
-                            <a href={item.originalUrl} target="_blank" rel="noopener noreferrer" className={styles.linkButton} style={{ marginBottom: '10px' }}>
+                            <a href={item.originalUrl} target="_blank" rel="noopener noreferrer" className={styles.linkButton}>
                                 Open Original File
                             </a>
                         )}


### PR DESCRIPTION
# Replace Hardcoded Colors & Inline Styles with CSS Variables

Issue [#14](https://github.com/Darkkal/web-gallery/issues/14) — Migrate all hardcoded hex colors and inline `style={{}}` to the CSS variable design system and CSS Modules.

## Scope Summary

Full audit found **~50 inline `style={{}}` occurrences** across 13 files, **11 hardcoded hex colors** (bypassing the design system), and **2 dead Tailwind classes**. The work naturally groups into three tiers based on risk and complexity.

## Proposed Changes

### 1. Design Tokens — `globals.css`

#### [MODIFY] [globals.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/globals.css)

Add semantic color variables to both `:root` (dark) and `[data-theme='light']`:

```css
/* Semantic Status Colors */
--color-success: 142 71% 45%;
--color-info: 217 91% 60%;
--color-danger: 0 84% 60%;
--color-warning: 38 92% 50%;
--color-muted-label: 215 16% 62%;  /* replaces #94a3b8 */
```

Light theme overrides:
```css
--color-success: 142 71% 45%;
--color-info: 217 91% 60%;
--color-danger: 0 72% 51%;
--color-warning: 38 92% 50%;
--color-muted-label: 215 20% 45%;
```

> [!NOTE]
> These map directly to the hardcoded hex values currently in use: `#4ade80` → success, `#60a5fa` → info, `#f87171` → danger, `#94a3b8` → muted-label.

---

### 2. Library Page — Hardcoded Colors (Primary Target)

#### [MODIFY] [page-client.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/library/page-client.tsx)

This file has the densest concentration of issues (11 inline `style={{color}}` attributes).

| Line | Current | Replacement |
|------|---------|-------------|
| 117, 124, 131, 136, 141 | `style={{ color: '#94a3b8' }}` | `className={styles.mutedLabel}` |
| 142 | `style={{ color: '#4ade80' }}` | `className={styles.resultAdded}` |
| 144 | `style={{ color: '#60a5fa' }}` | `className={styles.resultUpdated}` |
| 146, 152 | `style={{ color: '#f87171' }}` | `className={styles.resultDeleted}` |
| 223 | `style={{ marginTop: '1rem' }}` | Move `margin-top` into existing `.dangerNote` class |

#### [MODIFY] [page.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/library/page.module.css)

Add new utility classes:
```css
.mutedLabel { color: hsl(var(--color-muted-label)); }
.resultAdded { color: hsl(var(--color-success)); }
.resultUpdated { color: hsl(var(--color-info)); }
.resultDeleted { color: hsl(var(--color-danger)); }
```

Also migrate the hardcoded hex colors in existing CSS rules:
| Line | Current | Replacement |
|------|---------|-------------|
| 10 | `#ffffff, #94a3b8` gradient | `hsl(var(--foreground)), hsl(var(--color-muted-label))` |
| 107 | `#064e3b` / `#6ee7b7` | `hsl(var(--color-success) / 0.2)` / `hsl(var(--color-success))` |
| 118 | `#fca5a5` | `hsl(var(--color-danger) / 0.8)` |
| 123 | `#93c5fd` | `hsl(var(--color-info) / 0.8)` |
| 128, 133, 144 | `rgba(239, 68, 68, ...)` / `#ef4444` / `#dc2626` | `hsl(var(--color-danger) / ...)` |

---

### 3. Tags Page — Empty State

#### [MODIFY] [page.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/tags/page.tsx#L66)

Replace:
```tsx
<div style={{ textAlign: 'center', padding: '40px', color: '#888' }}>
```
With:
```tsx
<div className={styles.emptyState}>
```

#### [MODIFY] [page.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/tags/page.module.css)

Add:
```css
.emptyState {
    text-align: center;
    padding: 40px;
    color: hsl(var(--muted-foreground));
}
```

---

### 4. Sources — Dead Tailwind Classes & Inline Styles

#### [MODIFY] [SourceTableRow.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/sources/components/SourceTableRow.tsx)

| Line | Change |
|------|--------|
| 66 | `style={{ display: 'flex', gap: '4px' }}` → `className={styles.editActions}` |
| 68 | `className="text-green-500"` → `className={styles.iconSuccess}` (dead Tailwind → CSS Module) |
| 71 | `className="text-red-500"` → `className={styles.iconDanger}` (dead Tailwind → CSS Module) |
| 89 | `style={{ display: 'flex', ... }}` → `className={styles.editFields}` |
| 92, 99 | `style={{ padding, fontSize }}` → `className={styles.editInput}` |
| 107 | `style={{ fontWeight: 500 }}` → `className={styles.sourceTitle}` |
| 108 | `style={{ fontSize, color }}` → `className={styles.sourceUrl}` |
| 113 | `style={{ color, border }}` → `className={styles.tableBadge}` |

#### [MODIFY] [SourceCard.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/sources/components/SourceCard.tsx#L34)

| Line | Change |
|------|--------|
| 28-31 | `backgroundImage` inline style stays (dynamic value) — only refactor the fallback `backgroundColor` |
| 34 | `style={{ position: 'absolute', ... }}` → `className={styles.placeholderIcon}` |

#### [MODIFY] [AddSourceForm.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/sources/components/AddSourceForm.tsx)

| Line | Change |
|------|--------|
| 27 | `style={{ display: 'flex', gap, flex }}` → `className={styles.formInputRow}` |
| 35 | `style={{ flex: 2 }}` → `className={styles.inputWide}` |
| 43 | `style={{ flex: 1 }}` → Already covered by existing `.input` |

#### [MODIFY] [ControlsBar.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/sources/components/ControlsBar.tsx#L63)

| Line | Change |
|------|--------|
| 63 | `style={{ display: 'flex', gap }}` → `className={styles.viewToggle}` |

#### [MODIFY] [page-client.tsx (sources)](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/sources/page-client.tsx)

| Line | Change |
|------|--------|
| 145, 153, 154 | `style={{ width }}` on table headers → `className` with CSS width rules |
| 181 | `style={{ padding, textAlign, color }}` → `className={styles.emptyState}` |

#### [MODIFY] [page.module.css (sources)](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/sources/page.module.css)

Add all new CSS classes referenced above.

---

### 5. Scrape History Table — Status Badge Colors

#### [MODIFY] [history-table.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/scrape/history-table.tsx)

| Line | Change |
|------|--------|
| 86-90 | `style={{ textAlign: 'right' }}` on `<th>` → `className={styles.thRight}` |
| 103 | `style={{ animation, opacity }}` → `className={styles.runningPulse}` |
| 107-119 | Status badge inline styles (conditional `backgroundColor`/`color`) → data-attribute pattern: `data-status={item.status}` + CSS rules |
| 123-127 | `style={{ textAlign: 'right' }}` on `<td>` → `className={styles.tdRight}` |
| 127 | Error count conditional color → `className={item.errorCount ? styles.errorText : ''}` |
| 132 | Empty state inline → `className={styles.emptyCell}` |

#### [MODIFY] [page.module.css (scrape)](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/scrape/page.module.css)

Add:
```css
.thRight, .tdRight { text-align: right; }
.runningPulse { animation: pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite; opacity: 0.7; }
.badge[data-status="completed"] { background: hsl(var(--color-success) / 0.1); color: hsl(var(--color-success)); border: 1px solid currentColor; }
.badge[data-status="failed"] { background: hsl(var(--color-danger) / 0.1); color: hsl(var(--color-danger)); border: 1px solid currentColor; }
.badge[data-status="running"] { background: hsl(var(--color-info) / 0.1); color: hsl(var(--color-info)); border: 1px solid currentColor; }
.errorText { color: hsl(var(--destructive)); }
.emptyCell { text-align: center; padding: 3rem; color: hsl(var(--muted-foreground)); }
```

---

### 6. Lightbox — Tag Chips & Layout Inline Styles

#### [MODIFY] [Lightbox.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.tsx)

| Line | Change |
|------|--------|
| 287 | `style={{ gridColumn: '1 / -1' }}` → `className={styles.statItemFull}` |
| 303 | `style={{ textTransform: 'uppercase' }}` → Already uppercase via `.badge` — remove inline |
| 316 | `style={{ display: 'flex', ... }}` on tags container → styles already exist in `.tagsContainer`, just remove the inline style |
| 318-324 | Tag chip inline styles (`background`, `padding`, `borderRadius`, `fontSize`, `color: '#ccc'`) → fully absorb into existing `.tagChip` class |
| 336 | `style={{ marginBottom: '10px' }}` → `className` with added `margin-bottom` in `.linkButton + .linkButton` rule |

#### [MODIFY] [Lightbox.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.module.css)

Add/update:
```css
.statItemFull { grid-column: 1 / -1; }
.tagsContainer { display: flex; flex-wrap: wrap; gap: 4px; }
.tagChip {
    background: rgba(255, 255, 255, 0.1);
    padding: 2px 8px;
    border-radius: 12px;
    font-size: 12px;
    color: hsl(var(--muted-foreground));
}
.linkButton + .linkButton { margin-top: 10px; }
```

---

### 7. Gallery — Twitter Overlay & Load More

#### [MODIFY] [GalleryItem.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/components/GalleryItem.tsx#L72)

| Line | Change |
|------|--------|
| 66 | `style={{ width: '100%', height: 'auto' }}` — Keep (Next.js Image requires inline style for layout) |
| 72 | Twitter stats overlay inline styles → `className={styles.twitterOverlay}` |

#### [MODIFY] [FilterBar.tsx (gallery)](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/components/FilterBar.tsx)

| Line | Change |
|------|--------|
| 38 | `style={{ padding, lineHeight, ... }}` → `className={styles.selectionButton}` |
| 62 | `style={{ flex: 2 }}` → `className={styles.searchInput}` (add `flex: 2` to existing class) |

#### [MODIFY] [page-client.tsx (gallery)](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/page-client.tsx#L175)

| Line | Change |
|------|--------|
| 175 | `style={{ margin, display, padding }}` → `className={styles.loadMoreButton}` |

#### [MODIFY] [page.module.css (gallery)](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/page.module.css)

Add new classes and also migrate existing hardcoded hex colors:
- `.activeButton`: `#3b82f6` → `hsl(var(--color-info))` 
- `.selectedItem`: `#3b82f6` → `hsl(var(--color-info))`
- `.checkbox`: `rgba(59, 130, 246, 0.9)` → `hsl(var(--color-info) / 0.9)`
- `.deleteButton`: `#ef4444` / `#dc2626` → `hsl(var(--color-danger))` / `hsl(var(--color-danger) / 0.85)`
- `.secondaryDeleteButton`: `#f59e0b` / `#d97706` → `hsl(var(--color-warning))` / `hsl(var(--color-warning) / 0.85)`

---

### 8. Timeline FilterBar — Minor

#### [MODIFY] [FilterBar.tsx (timeline)](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/timeline/components/FilterBar.tsx#L27)

| Line | Change |
|------|--------|
| 27 | `style={{ flex: 1 }}` → Add `flex: 1` to the `.input` CSS class or add a `searchInput` class |

---

### 9. Lightbox CSS — Remaining Hardcoded Colors

#### [MODIFY] [Lightbox.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.module.css)

| Line | Current | Replacement |
|------|---------|-------------|
| 227 | `#f59e0b` | `hsl(var(--color-warning))` |
| 232 | `#ef4444` | `hsl(var(--color-danger))` |

---

## User Review Required

> [!IMPORTANT]
> **Inline styles for dynamic values** (e.g., `backgroundImage` on SourceCard, Next.js Image dimensions) will be **kept** since they depend on runtime data. Only static/presentational inline styles are being migrated.

> [!IMPORTANT]
> **PostCard cursor style** (`line 66, style={{ cursor: ... }}`) in `timeline/components/PostCard.tsx` is conditional based on data — this will remain as an inline style since the value is computed at render time.

## Open Questions

None — the issue is well-defined and the scope is clear.

## Verification Plan

### Automated Tests
- `npm run build` — ensure no TypeScript or CSS compilation errors
- `npx playwright test` — run existing E2E suite to verify no visual regressions

### Manual Verification
- Browser check of Library page (scan status colors), Sources page (table view edit icons), Gallery (selection outline, delete buttons), Scrape history (status badges), Lightbox (tags, source links), Tags (empty state)
