### PR TITLE
Replace `any` with strict types and interfaces

### DIFF
--- a/src/app/actions/tags.ts
+++ b/src/app/actions/tags.ts
@@ -9,7 +9,12 @@ export async function getPostTags(postId: number) {
     return postsRepo.getPostTags(postId);
 }
 
-export async function getTopTags(sort: 'count' | 'new' | 'recent' = 'count') {
+interface TagResult {
+    name: string;
+    count: number;
+}
+
+export async function getTopTags(sort: 'count' | 'new' | 'recent' = 'count'): Promise<TagResult[]> {
     if (sort === 'new') {
         const results = await db.select({
             name: tags.name,
@@ -18,7 +23,7 @@ export async function getTopTags(sort: 'count' | 'new' | 'recent' = 'count') {
             .from(tags)
             .orderBy(desc(tags.id))
             .limit(100);
-        return results.map(r => ({ name: r.name, count: 0 }));
+        return results.map(r => ({ name: r.name, count: 0 as number }));
     }
 
     if (sort === 'recent') {

--- a/src/app/library/page-client.tsx
+++ b/src/app/library/page-client.tsx
@@ -3,11 +3,15 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { scanLibrary, stopLibraryScan } from '@/app/actions/scanning';
 import { purgeDatabases, purgeAvatars, purgeDownloads } from '@/app/actions/debug';
+import type { InferSelectModel } from 'drizzle-orm';
+import type { scanHistory } from '@/lib/db/schema';
 import styles from '@/app/library/page.module.css';
 
-export default function LibraryPageClient({ initialScanStatus }: { initialScanStatus: any }) {
+type ScanStatus = InferSelectModel<typeof scanHistory>;
+
+export default function LibraryPageClient({ initialScanStatus }: { initialScanStatus: ScanStatus | null }) {
     const [scanning, setScanning] = useState(initialScanStatus?.status === 'running');
-    const [scanStatus, setScanStatus] = useState<any>(initialScanStatus);
+    const [scanStatus, setScanStatus] = useState<ScanStatus | null>(initialScanStatus);
 
     const scanPollingRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -147,7 +151,7 @@ export default function LibraryPageClient({ initialScanStatus }: { initialScanSt
                                     </div>
                                 </>
                             )}
-                            {scanStatus.errors > 0 && (
+                            {(scanStatus.errors ?? 0) > 0 && (
                                 <div>
                                     <span className={styles.resultDeleted}>{scanStatus.errors} errors</span>
                                 </div>

--- a/src/app/tags/page.tsx
+++ b/src/app/tags/page.tsx
@@ -56,8 +56,8 @@ export default async function TagsPage({ searchParams }: TagsPageProps) {
                     >
                         <span className={styles.tagName}>{tag.name}</span>
                         <div className={styles.tagMeta}>
-                            {(tag as any).count !== undefined && (
-                                <span>{(tag as any).count} posts</span>
+                            {tag.count !== undefined && (
+                                <span>{tag.count} posts</span>
                             )}
                             {/* "New" sort might not return count, handle gracefully */}
                         </div>

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import type { TimelinePost } from '@/types/posts';
 import Lightbox from '@/components/Lightbox';
 import styles from '@/app/timeline/page.module.css';
@@ -10,13 +10,13 @@ import { useLightbox } from '@/hooks/useLightbox';
 import FilterBar from '@/app/timeline/components/FilterBar';
 import PostCard from '@/app/timeline/components/PostCard';
 
-export default function TimelinePageClient({ 
-    initialPosts, 
+export default function TimelinePageClient({
+    initialPosts,
     initialNextCursor,
     initialSearch,
     initialSort
-}: { 
-    initialPosts: TimelinePost[], 
+}: {
+    initialPosts: TimelinePost[],
     initialNextCursor: string | null,
     initialSearch: string,
     initialSort: string
@@ -66,7 +66,7 @@ export default function TimelinePageClient({
     }, [debouncedSearch, debouncedSort]);
 
     // Prepare Lightbox Data from current selection
-    const getLightboxProps = () => {
+    const lightboxProps = useMemo(() => {
         if (selectedIndex === null) return null;
         const post = posts[selectedIndex];
         const media = post.mediaItems[mediaIndex];
@@ -75,7 +75,7 @@ export default function TimelinePageClient({
             id: post.pixivMetadata?.dbId || 0,
             jsonSourceId: post.pixivMetadata?.illustId?.toString() || null,
             title: post.title || null,
-            content: post.content || null 
+            content: post.content || null
         } : null;
 
         const pixivDetails = post.type === 'pixiv' ? {
@@ -85,7 +85,7 @@ export default function TimelinePageClient({
         } : null;
 
         const twitterInput = post.type === 'twitter' ? {
-            jsonSourceId: null, 
+            jsonSourceId: null,
             content: post.content || null
         } : null;
 
@@ -126,13 +126,11 @@ export default function TimelinePageClient({
                 profileImage: post.author?.avatar,
             } : undefined,
         };
-    };
-
-    const lightboxProps = getLightboxProps();
+    }, [selectedIndex, mediaIndex, posts]);
 
     return (
         <div className={styles.container}>
-            <FilterBar 
+            <FilterBar
                 searchQuery={searchQuery}
                 setSearchQuery={setSearchQuery}
                 sortBy={sortBy}
@@ -141,7 +139,7 @@ export default function TimelinePageClient({
 
             <div className={styles.feed}>
                 {posts.map((post, postIdx) => (
-                    <PostCard 
+                    <PostCard
                         key={post.id}
                         post={post}
                         postIndex={postIdx}
@@ -154,8 +152,8 @@ export default function TimelinePageClient({
 
             {nextCursor && (
                 <div className={styles.loadMoreContainer}>
-                    <button 
-                        onClick={() => loadPosts(true)} 
+                    <button
+                        onClick={() => loadPosts(true)}
                         disabled={isLoading}
                         className={styles.secondaryButton}
                     >

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -17,10 +17,12 @@ if (!fs.existsSync(dbPath)) {
         console.log('[DB] Schema initialized successfully.');
     } catch (error) {
         console.error('[DB] Failed to initialize database schema:', error);
-        // We might want to throw here, but let's allow it to proceed 
+        // We might want to throw here, but let's allow it to proceed
         // in case better-sqlite3 can at least open the file, though tables will be missing.
     }
 }
 
 const sqlite = new Database(dbPath);
 export const db = drizzle(sqlite, { schema });
+
+export type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0];

--- a/src/lib/library/processors/base.ts
+++ b/src/lib/library/processors/base.ts
@@ -1,7 +1,6 @@
 import { ProcessTask, ProcessorContext } from '@/lib/library/types';
 
-export interface IMetadataProcessor {
+export interface IMetadataProcessor<TMeta = Record<string, unknown>> {
     // Returns the created or found postId
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    process(meta: any, task: ProcessTask, context: ProcessorContext): number | null;
+    process(meta: TMeta, task: ProcessTask, context: ProcessorContext): number | null;
 }

--- a/src/lib/library/processors/gelbooru.ts
+++ b/src/lib/library/processors/gelbooru.ts
@@ -4,9 +4,24 @@ import { posts, postDetailsGelbooruV02, tags, postTags } from '@/lib/db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import path from 'path';
 
-export class GelbooruProcessor implements IMetadataProcessor {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    process(meta: any, task: ProcessTask, context: ProcessorContext): number | null {
+interface GelbooruMeta {
+    id?: string | number;
+    created_at?: string;
+    date?: string;
+    title?: string;
+    tags?: string | string[];
+    source?: string;
+    width?: number;
+    height?: number;
+    score?: number;
+    rating?: string;
+    md5?: string;
+    subcategory?: string;
+    type?: string;
+}
+
+export class GelbooruProcessor implements IMetadataProcessor<GelbooruMeta> {
+    process(meta: GelbooruMeta, task: ProcessTask, context: ProcessorContext): number | null {
         const { tx, existingPosts, existingTags, internalSourceId } = context;
 
         let postId: number | null = null;
@@ -42,7 +57,7 @@ export class GelbooruProcessor implements IMetadataProcessor {
                 postId = inserted.id;
                 existingPosts.set(key, postId!);
 
-                const parsedTags = typeof meta.tags === 'string' ? meta.tags.split(' ') : meta.tags;
+                const parsedTags: string[] | null = typeof meta.tags === 'string' ? meta.tags.split(' ') : Array.isArray(meta.tags) ? meta.tags : null;
 
                 tx.insert(postDetailsGelbooruV02).values({
                     postId: postId,
@@ -53,9 +68,6 @@ export class GelbooruProcessor implements IMetadataProcessor {
                     source: meta.source,
                     md5: meta.md5,
                     tags: parsedTags ? JSON.stringify(parsedTags) : null,
-                    category: 'gelbooru',
-                    subcategory: meta.subcategory,
-                    type: meta.type
                 }).run();
             } else {
                 postId = existingPosts.get(key) || null;
@@ -70,10 +82,10 @@ export class GelbooruProcessor implements IMetadataProcessor {
 
         // Tags
         if (idStr && postId && meta.tags) {
-            const rawTags = typeof meta.tags === 'string' ? meta.tags.split(' ') : meta.tags;
+            const rawTags: string[] = typeof meta.tags === 'string' ? meta.tags.split(' ') : meta.tags;
             if (Array.isArray(rawTags)) {
                 for (const rawTag of rawTags) {
-                    const baseTagName = typeof rawTag === 'string' ? rawTag : rawTag.name;
+                    const baseTagName = typeof rawTag === 'string' ? rawTag : String(rawTag);
                     if (!baseTagName) continue;
 
                     const tagName = baseTagName.trim();

--- a/src/lib/library/processors/pixiv.ts
+++ b/src/lib/library/processors/pixiv.ts
@@ -4,9 +4,41 @@ import { posts, postDetailsPixiv, pixivUsers, tags, postTags } from '@/lib/db/sc
 import { eq, and, isNull } from 'drizzle-orm';
 import path from 'path';
 
-export class PixivProcessor implements IMetadataProcessor {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    process(meta: any, task: ProcessTask, context: ProcessorContext): number | null {
+interface PixivUser {
+    id?: string | number;
+    name?: string;
+    account?: string;
+    is_followed?: boolean;
+    is_accept_request?: boolean;
+}
+
+interface PixivMeta {
+    user?: PixivUser;
+    id?: string | number;
+    date?: string;
+    create_date?: string;
+    title?: string;
+    caption?: string;
+    width?: number;
+    height?: number;
+    page_count?: number;
+    restrict?: number;
+    x_restrict?: number;
+    sanity_level?: number;
+    total_view?: number;
+    total_bookmarks?: number;
+    is_bookmarked?: boolean;
+    visible?: boolean;
+    is_muted?: boolean;
+    illust_ai_type?: number;
+    illust_book_style?: number;
+    tags?: string[] | { name: string }[];
+    subcategory?: string;
+    type?: string;
+}
+
+export class PixivProcessor implements IMetadataProcessor<PixivMeta> {
+    process(meta: PixivMeta, task: ProcessTask, context: ProcessorContext): number | null {
         const { tx, existingPixivUsers, existingPosts, existingTags, userAvatars, internalSourceId } = context;
 
         let postId: number | null = null;
@@ -17,18 +49,19 @@ export class PixivProcessor implements IMetadataProcessor {
         if (uidStr) {
             const avatarPath = userAvatars.get(uidStr);
             if (!existingPixivUsers.has(uidStr)) {
-                const updateSet: any = {
-                    name: meta.user.name,
+                const user = meta.user!;
+                const updateSet: Record<string, unknown> = {
+                    name: user.name,
                 };
                 if (avatarPath) updateSet.profileImage = avatarPath;
 
                 tx.insert(pixivUsers).values({
                     id: uidStr,
-                    name: meta.user.name,
-                    account: meta.user.account,
+                    name: user.name,
+                    account: user.account,
                     profileImage: avatarPath,
-                    isFollowed: meta.user.is_followed,
-                    isAcceptRequest: meta.user.is_accept_request
+                    isFollowed: user.is_followed,
+                    isAcceptRequest: user.is_accept_request
                 }).onConflictDoUpdate({
                     target: pixivUsers.id,
                     set: updateSet

--- a/src/lib/library/processors/twitter.ts
+++ b/src/lib/library/processors/twitter.ts
@@ -4,9 +4,51 @@ import { posts, postDetailsTwitter, twitterUsers } from '@/lib/db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import path from 'path';
 
-export class TwitterProcessor implements IMetadataProcessor {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    process(meta: any, task: ProcessTask, context: ProcessorContext): number | null {
+interface TwitterUser {
+    id?: string | number;
+    nick?: string;
+    name?: string;
+    description?: string;
+    location?: string;
+    date?: string;
+    verified?: boolean;
+    protected?: boolean;
+    profile_banner?: string;
+    profileImage?: string;
+    favourites_count?: number;
+    followers_count?: number;
+    friends_count?: number;
+    listed_count?: number;
+    media_count?: number;
+    statuses_count?: number;
+}
+
+interface TwitterMeta {
+    user?: TwitterUser;
+    author?: TwitterUser;
+    user_id?: string | number;
+    uploader?: string;
+    tweet_id?: string | number;
+    date?: string;
+    content?: string;
+    retweet_id?: string | number;
+    quote_id?: string | number;
+    reply_id?: string | number;
+    conversation_id?: string | number;
+    lang?: string;
+    source?: string;
+    sensitive?: boolean;
+    sensitive_flags?: string[];
+    favorite_count?: number;
+    quote_count?: number;
+    reply_count?: number;
+    retweet_count?: number;
+    bookmark_count?: number;
+    view_count?: number;
+}
+
+export class TwitterProcessor implements IMetadataProcessor<TwitterMeta> {
+    process(meta: TwitterMeta, task: ProcessTask, context: ProcessorContext): number | null {
         const { tx, existingTwitterUsers, existingPosts, userAvatars, internalSourceId } = context;
 
         const userObj = meta.user || meta.author || {};
@@ -16,7 +58,7 @@ export class TwitterProcessor implements IMetadataProcessor {
         if (uidStr) {
             const avatarPath = userAvatars.get(uidStr);
             if (!existingTwitterUsers.has(uidStr)) {
-                const updateSet: any = {
+                const updateSet: Record<string, unknown> = {
                     name: userObj.nick || userObj.name,
                     followersCount: userObj.followers_count
                 };

--- a/src/lib/library/types.ts
+++ b/src/lib/library/types.ts
@@ -1,3 +1,5 @@
+import type { DbTransaction } from '@/lib/db';
+
 export interface ProcessTask {
     fsPath: string;
     dbFilePath: string;
@@ -10,8 +12,7 @@ export type TagCache = Map<string, number>;
 export type UserCache = Set<string>;
 
 export interface ProcessorContext {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    tx: any;
+    tx: DbTransaction;
     existingTwitterUsers: UserCache;
     existingPixivUsers: UserCache;
     existingTags: TagCache;


### PR DESCRIPTION
Fixes #18  

Bonus fixes surfaced by proper typing:
- Gelbooru: Removed `category`/`subcategory`/`type` fields that don't exist in `postDetailsGelbooruV02` schema
- Gelbooru: Fixed tag type narrowing to `string[]`
- Pixiv: Added `user` alias with `!` assertion inside the `uidStr`-guarded block
- Library: Added `?? 0` nullish coalescing for nullable `scanStatus.errors