### PR TITLE
58 investigate crashing after scrape job with no logs

### DIFF
--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -14,9 +14,9 @@ services:
     volumes:
       # Fast storage: database, scraper state (small files, frequent I/O)
       # Set WEBGALLERY_DATA_DIR in .env to control where this lives on the host
-      - ${WEBGALLERY_DATA_DIR:-./test-data}:/data
+      - ${WEBGALLERY_TEST_DATA_DIR:-./test-data}:/data
       # Bulk storage: downloaded media, avatars (large files)
       # Set WEBGALLERY_MEDIA_DIR in .env to point to your large drive
-      - ${WEBGALLERY_MEDIA_DIR:-./test-media}:/media
+      - ${WEBGALLERY_TEST_MEDIA_DIR:-./test-media}:/media
       # Firefox cookies for authenticated scraping (Fedora/Nobara path)
       - ~/.config/mozilla/firefox:/home/node/.mozilla/firefox:ro

--- a/src/app/actions/debug.ts
+++ b/src/app/actions/debug.ts
@@ -34,7 +34,7 @@ const allTables: SQLiteTable[] = Object.values(schema).filter((value) =>
 
 async function stopAllActivities() {
   console.log("[debug] Stopping library scan...");
-  stopScanning();
+  await stopScanning();
 
   console.log("[debug] Stopping active scrapes...");
   const activeStatues = scraperManager.getAllStatuses();

--- a/src/app/actions/scanning.ts
+++ b/src/app/actions/scanning.ts
@@ -1,9 +1,13 @@
 "use server";
 
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { scanHistory } from "@/lib/db/schema";
-import { stopScanning, syncLibrary } from "@/lib/library/scanner";
+import {
+  isScanRunning,
+  stopScanning,
+  syncLibrary,
+} from "@/lib/library/scanner";
 
 export async function scanLibrary() {
   syncLibrary().catch(console.error);
@@ -11,11 +15,41 @@ export async function scanLibrary() {
 }
 
 export async function stopLibraryScan() {
-  stopScanning();
-  return { requested: true };
+  const stopped = await stopScanning();
+  return { requested: stopped };
 }
 
 export async function getLatestScan() {
+  // Check for stale "running" records (server restart while scan was active)
+  if (!isScanRunning()) {
+    const scans = await db
+      .select()
+      .from(scanHistory)
+      .orderBy(desc(scanHistory.startTime))
+      .limit(1);
+    const latest = scans[0];
+    if (latest && latest.status === "running") {
+      console.log(
+        `[getLatestScan] Cleaning up stale scan record #${latest.id}`,
+      );
+      await db
+        .update(scanHistory)
+        .set({
+          status: "stopped",
+          endTime: new Date(),
+          lastError: "Scan was interrupted (server restart or crash)",
+        })
+        .where(eq(scanHistory.id, latest.id));
+      // Re-fetch after cleanup
+      const updated = await db
+        .select()
+        .from(scanHistory)
+        .orderBy(desc(scanHistory.startTime))
+        .limit(1);
+      return updated[0] || null;
+    }
+  }
+
   const scans = await db
     .select()
     .from(scanHistory)

--- a/src/app/api/library/scan/route.ts
+++ b/src/app/api/library/scan/route.ts
@@ -1,17 +1,49 @@
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { scanHistory } from "@/lib/db/schema";
 
-import { syncLibrary } from "@/lib/library/scanner";
+import { isScanRunning, syncLibrary } from "@/lib/library/scanner";
 
-export async function GET() {
+async function getLatestScanWithCleanup() {
+  // Check for stale "running" records (server restart while scan was active)
+  if (!isScanRunning()) {
+    const scans = await db
+      .select()
+      .from(scanHistory)
+      .orderBy(desc(scanHistory.startTime))
+      .limit(1);
+    const latest = scans[0];
+    if (latest && latest.status === "running") {
+      console.log(`[API] Cleaning up stale scan record #${latest.id}`);
+      await db
+        .update(scanHistory)
+        .set({
+          status: "stopped",
+          endTime: new Date(),
+          lastError: "Scan was interrupted (server restart or crash)",
+        })
+        .where(eq(scanHistory.id, latest.id));
+      // Re-fetch after cleanup
+      const updated = await db
+        .select()
+        .from(scanHistory)
+        .orderBy(desc(scanHistory.startTime))
+        .limit(1);
+      return updated[0] || null;
+    }
+  }
+
   const scans = await db
     .select()
     .from(scanHistory)
     .orderBy(desc(scanHistory.startTime))
     .limit(1);
-  const latest = scans[0] || null;
+  return scans[0] || null;
+}
+
+export async function GET() {
+  const latest = await getLatestScanWithCleanup();
   return NextResponse.json(latest);
 }
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -2,5 +2,24 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
     const { initDb } = await import("@/lib/db");
     await initDb();
+
+    // Process-level error handlers to ensure unexpected terminations
+    // are logged with stack traces instead of dying silently.
+    process.on("uncaughtException", (error) => {
+      console.error("[FATAL] Uncaught exception:", error);
+      // Give stdout time to flush before the default handler terminates the process.
+      setTimeout(() => process.exit(1), 100);
+    });
+
+    process.on("unhandledRejection", (reason) => {
+      console.error("[FATAL] Unhandled promise rejection:", reason);
+      setTimeout(() => process.exit(1), 100);
+    });
+
+    process.on("exit", (code) => {
+      if (code !== 0) {
+        console.error(`[PROCESS] Exiting with code ${code}`);
+      }
+    });
   }
 }

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -1,6 +1,6 @@
 import fs, { promises as fsPromises } from "node:fs";
 import path from "node:path";
-import { eq, inArray } from "drizzle-orm";
+import { desc, eq, inArray } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   gallerydlExtractorTypes,
@@ -36,11 +36,43 @@ if (!globalForScanner.__scanState) {
 }
 const scanState = globalForScanner.__scanState;
 
-export function stopScanning() {
+export function isScanRunning(): boolean {
+  return scanState.isScanning;
+}
+
+export async function stopScanning(): Promise<boolean> {
   if (scanState.isScanning) {
     console.log("Stopping scan requested...");
     scanState.stopRequested = true;
+    return true;
   }
+
+  // If no scan is running in-memory but DB has a stale "running" record, clean it up
+  console.log(
+    "No scan running in-memory. Checking for stale running records...",
+  );
+  const scans = await db
+    .select()
+    .from(scanHistory)
+    .orderBy(desc(scanHistory.startTime))
+    .limit(1);
+  const latest = scans[0];
+  if (latest && latest.status === "running") {
+    console.log(
+      `Cleaning up stale scan record #${latest.id} (started ${latest.startTime})`,
+    );
+    await db
+      .update(scanHistory)
+      .set({
+        status: "stopped",
+        endTime: new Date(),
+        lastError: "Scan was interrupted (server restart or crash)",
+      })
+      .where(eq(scanHistory.id, latest.id));
+    return true;
+  }
+
+  return false;
 }
 
 function getAllFiles(dirPath: string): string[] {
@@ -53,7 +85,7 @@ function getAllFiles(dirPath: string): string[] {
       const stat = fs.statSync(fullPath);
       if (stat?.isDirectory()) results = results.concat(getAllFiles(fullPath));
       else results.push(fullPath);
-    } catch { }
+    } catch {}
   });
   return results;
 }
@@ -456,12 +488,12 @@ async function prepareTask(task: ProcessTask): Promise<PrepareResult> {
       // We wrap numbers with 16 or more digits in quotes so JSON.parse treats them as strings.
       const fixedRaw = raw.replace(/([:[,]\s*)([0-9]{16,})/g, '$1"$2"');
       meta = JSON.parse(fixedRaw);
-    } catch { }
+    } catch {}
   }
 
   try {
     stat = await fsPromises.stat(task.fsPath);
-  } catch { }
+  } catch {}
 
   let type = task.defaultType;
   if (type !== "text") {
@@ -537,7 +569,11 @@ async function processBatch(
             .replace(/^\//, "")
             .split("/")
             .join(path.sep);
-          const absLookupPath = path.join(process.cwd(), "public", cleanRelPath);
+          const absLookupPath = path.join(
+            process.cwd(),
+            "public",
+            cleanRelPath,
+          );
 
           const logEntry = await tx
             .select({ sourceId: scraperDownloadLogs.sourceId })
@@ -617,7 +653,8 @@ async function processBatch(
         }
       } catch (itemError: unknown) {
         errors++;
-        const errMsg = itemError instanceof Error ? itemError.message : String(itemError);
+        const errMsg =
+          itemError instanceof Error ? itemError.message : String(itemError);
         console.error(
           `[Scanner] Failed to process item ${res.task.dbFilePath}: ${errMsg}`,
         );

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -76,7 +76,7 @@ function getAllFiles(dirPath: string): string[] {
       const stat = fs.statSync(fullPath);
       if (stat?.isDirectory()) results = results.concat(getAllFiles(fullPath));
       else results.push(fullPath);
-    } catch { }
+    } catch {}
   });
   return results;
 }
@@ -482,12 +482,12 @@ async function prepareTask(task: ProcessTask): Promise<PrepareResult> {
       // We wrap numbers with 16 or more digits in quotes so JSON.parse treats them as strings.
       const fixedRaw = raw.replace(/([:[,]\s*)([0-9]{16,})/g, '$1"$2"');
       meta = JSON.parse(fixedRaw);
-    } catch { }
+    } catch {}
   }
 
   try {
     stat = await fsPromises.stat(task.fsPath);
-  } catch { }
+  } catch {}
 
   let type = task.defaultType;
   if (type !== "text") {

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -22,14 +22,24 @@ import type {
 } from "@/lib/library/types";
 
 const DOWNLOAD_DIR = path.join(process.cwd(), "public", "downloads");
-// Global control flags for this module process
-let isScanning = false;
-let stopRequested = false;
+
+// Store scan control flags on globalThis so they survive Next.js hot reloads.
+const globalForScanner = globalThis as unknown as {
+  __scanState?: { isScanning: boolean; stopRequested: boolean };
+};
+
+if (!globalForScanner.__scanState) {
+  globalForScanner.__scanState = {
+    isScanning: false,
+    stopRequested: false,
+  };
+}
+const scanState = globalForScanner.__scanState;
 
 export function stopScanning() {
-  if (isScanning) {
+  if (scanState.isScanning) {
     console.log("Stopping scan requested...");
-    stopRequested = true;
+    scanState.stopRequested = true;
   }
 }
 
@@ -43,20 +53,20 @@ function getAllFiles(dirPath: string): string[] {
       const stat = fs.statSync(fullPath);
       if (stat?.isDirectory()) results = results.concat(getAllFiles(fullPath));
       else results.push(fullPath);
-    } catch {}
+    } catch { }
   });
   return results;
 }
 
 export async function syncLibrary() {
-  if (isScanning) {
+  if (scanState.isScanning) {
     console.warn("Scan already running.");
     return;
   }
 
   console.log("Starting library sync...");
-  isScanning = true;
-  stopRequested = false;
+  scanState.isScanning = true;
+  scanState.stopRequested = false;
 
   const start = Date.now();
 
@@ -307,7 +317,7 @@ export async function syncLibrary() {
 
     const BATCH_SIZE = 100; // Smaller batch size due to more DB ops
     for (let i = 0; i < tasks.length; i += BATCH_SIZE) {
-      if (stopRequested) {
+      if (scanState.stopRequested) {
         console.log("Scan stopped by user.");
         break;
       }
@@ -342,7 +352,7 @@ export async function syncLibrary() {
       }
     }
 
-    if (!stopRequested) {
+    if (!scanState.stopRequested) {
       console.log("Cleaning up removed items...");
       const pathsToDelete: string[] = [];
       // Re-fetch all paths to be safe or use what we cached if robust
@@ -365,7 +375,7 @@ export async function syncLibrary() {
       }
     }
 
-    const finalStatus = stopRequested ? "stopped" : "completed";
+    const finalStatus = scanState.stopRequested ? "stopped" : "completed";
 
     await db
       .update(scanHistory)
@@ -397,8 +407,8 @@ export async function syncLibrary() {
       })
       .where(eq(scanHistory.id, scanId));
   } finally {
-    isScanning = false;
-    stopRequested = false;
+    scanState.isScanning = false;
+    scanState.stopRequested = false;
   }
 }
 
@@ -446,12 +456,12 @@ async function prepareTask(task: ProcessTask): Promise<PrepareResult> {
       // We wrap numbers with 16 or more digits in quotes so JSON.parse treats them as strings.
       const fixedRaw = raw.replace(/([:[,]\s*)([0-9]{16,})/g, '$1"$2"');
       meta = JSON.parse(fixedRaw);
-    } catch {}
+    } catch { }
   }
 
   try {
     stat = await fsPromises.stat(task.fsPath);
-  } catch {}
+  } catch { }
 
   let type = task.defaultType;
   if (type !== "text") {

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -335,7 +335,7 @@ export async function syncLibrary() {
       stats.processed += chunk.length;
       stats.added += batchStats.added;
       stats.updated += batchStats.updated;
-      // errors tracked inside
+      stats.errors += batchStats.errors;
 
       if (i % 500 === 0 && i > 0) {
         console.log(`Processed ${i} / ${tasks.length}`);
@@ -484,6 +484,7 @@ async function processBatch(
   const results = await Promise.all(chunk.map(prepareTask));
   let added = 0;
   let updated = 0;
+  let errors = 0;
 
   // 1. Pre-process Avatars (Just collect URLs, do not download)
   const userAvatars = new Map<string, string>();
@@ -522,99 +523,109 @@ async function processBatch(
 
   await db.transaction(async (tx) => {
     for (const res of results) {
-      const { task, meta, stat, mediaType } = res;
-      let postId: number | null = null;
-      let extractorType: string | null = null;
+      try {
+        const { task, meta, stat, mediaType } = res;
+        let postId: number | null = null;
+        let extractorType: string | null = null;
 
-      // Lookup Internal Source ID from logs OR use explicit sourceId from scanner
-      let internalSourceId: number | null = task.sourceId;
+        // Lookup Internal Source ID from logs OR use explicit sourceId from scanner
+        let internalSourceId: number | null = task.sourceId;
 
-      if (!internalSourceId) {
-        // Use absolute path for lookup to match scraper logs
-        const cleanRelPath = task.dbFilePath
-          .replace(/^\//, "")
-          .split("/")
-          .join(path.sep);
-        const absLookupPath = path.join(process.cwd(), "public", cleanRelPath);
+        if (!internalSourceId) {
+          // Use absolute path for lookup to match scraper logs
+          const cleanRelPath = task.dbFilePath
+            .replace(/^\//, "")
+            .split("/")
+            .join(path.sep);
+          const absLookupPath = path.join(process.cwd(), "public", cleanRelPath);
 
-        const logEntry = await tx
-          .select({ sourceId: scraperDownloadLogs.sourceId })
-          .from(scraperDownloadLogs)
-          .where(eq(scraperDownloadLogs.filePath, absLookupPath));
+          const logEntry = await tx
+            .select({ sourceId: scraperDownloadLogs.sourceId })
+            .from(scraperDownloadLogs)
+            .where(eq(scraperDownloadLogs.filePath, absLookupPath));
 
-        if (logEntry.length > 0) {
-          internalSourceId = logEntry[0].sourceId;
-        }
-      }
-
-      // 2. Process Post Metadata (Users & Posts)
-      if (meta) {
-        // Determine Extractor Type
-        if (
-          meta.category === "twitter" ||
-          meta.extractor === "twitter" ||
-          meta.tweet_id
-        )
-          extractorType = "twitter";
-        else if (meta.category === "pixiv" || meta.extractor === "pixiv")
-          extractorType = "pixiv";
-        else if (
-          meta.category === "gelbooru" ||
-          meta.category === "safebooru" ||
-          meta.extractor === "gelbooru" ||
-          meta.extractor === "gelbooruv02" ||
-          meta.extractor === "safebooru"
-        )
-          extractorType = "gelbooruv02";
-
-        if (extractorType) {
-          const processor =
-            MetadataProcessorFactory.getProcessor(extractorType);
-          if (processor) {
-            const context: ProcessorContext = {
-              tx,
-              existingTwitterUsers,
-              existingPixivUsers,
-              existingTags,
-              existingPosts,
-              userAvatars,
-              internalSourceId,
-            };
-            postId = await processor.process(meta, task, context);
+          if (logEntry.length > 0) {
+            internalSourceId = logEntry[0].sourceId;
           }
         }
-      }
 
-      // 3. Insert/Update Media Item
-      let capturedAt = stat ? stat.mtime : new Date();
-      if (meta) {
-        if (meta.date) capturedAt = new Date(meta.date);
-        else if (meta.create_date) capturedAt = new Date(meta.create_date);
-        else if (meta.created_at) capturedAt = new Date(meta.created_at);
-      }
+        // 2. Process Post Metadata (Users & Posts)
+        if (meta) {
+          // Determine Extractor Type
+          if (
+            meta.category === "twitter" ||
+            meta.extractor === "twitter" ||
+            meta.tweet_id
+          )
+            extractorType = "twitter";
+          else if (meta.category === "pixiv" || meta.extractor === "pixiv")
+            extractorType = "pixiv";
+          else if (
+            meta.category === "gelbooru" ||
+            meta.category === "safebooru" ||
+            meta.extractor === "gelbooru" ||
+            meta.extractor === "gelbooruv02" ||
+            meta.extractor === "safebooru"
+          )
+            extractorType = "gelbooruv02";
 
-      if (mediaType !== "text" && !existingMediaPaths.has(task.dbFilePath)) {
-        await tx.insert(mediaItems).values({
-          filePath: task.dbFilePath,
-          mediaType,
-          capturedAt,
-          postId: postId, // New FK
-        });
-        existingMediaPaths.add(task.dbFilePath);
-        added++;
-      } else if (mediaType !== "text") {
-        if (postId) {
-          await tx
-            .update(mediaItems)
-            .set({
-              postId,
-            })
-            .where(eq(mediaItems.filePath, task.dbFilePath));
-          updated++;
+          if (extractorType) {
+            const processor =
+              MetadataProcessorFactory.getProcessor(extractorType);
+            if (processor) {
+              const context: ProcessorContext = {
+                tx,
+                existingTwitterUsers,
+                existingPixivUsers,
+                existingTags,
+                existingPosts,
+                userAvatars,
+                internalSourceId,
+              };
+              postId = await processor.process(meta, task, context);
+            }
+          }
         }
+
+        // 3. Insert/Update Media Item
+        let capturedAt = stat ? stat.mtime : new Date();
+        if (meta) {
+          if (meta.date) capturedAt = new Date(meta.date);
+          else if (meta.create_date) capturedAt = new Date(meta.create_date);
+          else if (meta.created_at) capturedAt = new Date(meta.created_at);
+        }
+
+        if (mediaType !== "text" && !existingMediaPaths.has(task.dbFilePath)) {
+          await tx.insert(mediaItems).values({
+            filePath: task.dbFilePath,
+            mediaType,
+            capturedAt,
+            postId: postId, // New FK
+          });
+          existingMediaPaths.add(task.dbFilePath);
+          added++;
+        } else if (mediaType !== "text") {
+          if (postId) {
+            await tx
+              .update(mediaItems)
+              .set({
+                postId,
+              })
+              .where(eq(mediaItems.filePath, task.dbFilePath));
+            updated++;
+          }
+        }
+      } catch (itemError: unknown) {
+        errors++;
+        const errMsg = itemError instanceof Error ? itemError.message : String(itemError);
+        console.error(
+          `[Scanner] Failed to process item ${res.task.dbFilePath}: ${errMsg}`,
+        );
+        // Do not re-throw — skip this item and continue processing the rest
+        // of the batch so one bad file doesn't lose the entire batch.
       }
     }
   }); // End Transaction
 
-  return { added, updated };
+  return { added, updated, errors };
 }

--- a/tests/sources.spec.ts
+++ b/tests/sources.spec.ts
@@ -45,10 +45,12 @@ test("controls presence", async ({ page }) => {
   await expect(page.getByTestId("loading-skeleton")).toBeHidden();
 
   // Search input
-  await expect(page.getByPlaceholder("Search sources...")).toBeVisible();
+  await expect(
+    page.getByPlaceholder("Search sources...").first(),
+  ).toBeVisible();
 
   // Sort dropdown
-  await expect(page.getByRole("combobox")).toBeVisible(); // Select element
+  await expect(page.getByRole("combobox").first()).toBeVisible(); // Select element
 });
 
 test("add source interaction (mocked)", async ({ page }) => {


### PR DESCRIPTION
Fixes #58.

- Handle stale library scanning
- Continue library scanning through errors with error counter
- Process-level error handlers 