### PR TITLE
Resume from cursor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,29 +1,52 @@
-**/.classpath
-**/.dockerignore
-**/.env
-**/.git
-**/.gitignore
-**/.project
-**/.settings
-**/.toolstarget
-**/.vs
-**/.vscode
-**/*.*proj.user
-**/*.dbmdl
-**/*.jfm
-**/charts
-**/docker-compose*
-**/compose*
-**/Dockerfile*
-**/node_modules
-**/npm-debug.log
-**/obj
-**/secrets.dev.yaml
-**/values.dev.yaml
-**/.next
-**/test-data
-**/test-media
-**/prod-data
-**/prod-media
+# Version control
+.git
+.gitignore
+
+# IDE / Editor
+.classpath
+.project
+.settings
+.vs
+.vscode
+.toolstarget
+*.dbmdl
+*.jfm
+*.*proj.user
+
+# Dependencies
+node_modules
+npm-debug.log
+
+# Build output
+.next
+
+# Docker / Compose
+Dockerfile*
+docker-compose*
+compose*
+
+# Runtime data (mounted as volumes in production)
+data
+scratch
+sqlite.db
+public/downloads
+public/avatars
+
+# Test artifacts
+test-results
+test-data
+test-media
+
+# Secrets
+.env
+secrets.dev.yaml
+values.dev.yaml
+
+# Production data mounts
+prod-data
+prod-media
+
+# Documentation
 LICENSE
 README.md
+charts

--- a/drizzle/0003_luxuriant_hobgoblin.sql
+++ b/drizzle/0003_luxuriant_hobgoblin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scrape_history` ADD `cursor` text;

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1363 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "4e060207-c201-405f-a3fa-2e466f3f0d92",
+  "prevId": "074a0714-ba3a-4636-9173-20b3d35c0e4d",
+  "tables": {
+    "collection_items": {
+      "name": "collection_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "collection_id": {
+          "name": "collection_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "collection_items_collection_id_collections_id_fk": {
+          "name": "collection_items_collection_id_collections_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "collections",
+          "columnsFrom": ["collection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "collection_items_media_item_id_media_items_id_fk": {
+          "name": "collection_items_media_item_id_media_items_id_fk",
+          "tableFrom": "collection_items",
+          "tableTo": "media_items",
+          "columnsFrom": ["media_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "collections": {
+      "name": "collections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "gallerydl_extractor_types": {
+      "name": "gallerydl_extractor_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_post_id_posts_id_fk": {
+          "name": "media_items_post_id_posts_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pixiv_users": {
+      "name": "pixiv_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_followed": {
+          "name": "is_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_accept_request": {
+          "name": "is_accept_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_gelbooruv02": {
+      "name": "post_details_gelbooruv02",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "md5": {
+          "name": "md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_gelbooruv02_post_id_posts_id_fk": {
+          "name": "post_details_gelbooruv02_post_id_posts_id_fk",
+          "tableFrom": "post_details_gelbooruv02",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_pixiv": {
+      "name": "post_details_pixiv",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restrict": {
+          "name": "restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x_restrict": {
+          "name": "x_restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sanity_level": {
+          "name": "sanity_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_view": {
+          "name": "total_view",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_bookmarks": {
+          "name": "total_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_bookmarked": {
+          "name": "is_bookmarked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_ai_type": {
+          "name": "illust_ai_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_book_style": {
+          "name": "illust_book_style",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_pixiv_post_id_posts_id_fk": {
+          "name": "post_details_pixiv_post_id_posts_id_fk",
+          "tableFrom": "post_details_pixiv",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_twitter": {
+      "name": "post_details_twitter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retweet_id": {
+          "name": "retweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_id": {
+          "name": "reply_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive_flags": {
+          "name": "sensitive_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite_count": {
+          "name": "favorite_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_count": {
+          "name": "quote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retweet_count": {
+          "name": "retweet_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bookmark_count": {
+          "name": "bookmark_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_twitter_post_id_posts_id_fk": {
+          "name": "post_details_twitter_post_id_posts_id_fk",
+          "tableFrom": "post_details_twitter",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_tag_id_post_id_pk": {
+          "columns": ["tag_id", "post_id"],
+          "name": "post_tags_tag_id_post_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_source_id": {
+          "name": "json_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_source_id": {
+          "name": "internal_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_path": {
+          "name": "metadata_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_internal_source_id_sources_id_fk": {
+          "name": "posts_internal_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["internal_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_history": {
+      "name": "scan_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_processed": {
+          "name": "files_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_added": {
+          "name": "files_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_updated": {
+          "name": "files_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_deleted": {
+          "name": "files_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scrape_history": {
+      "name": "scrape_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_downloaded": {
+          "name": "files_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_processed": {
+          "name": "posts_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_speed": {
+          "name": "average_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scrape_history_source_id_sources_id_fk": {
+          "name": "scrape_history_source_id_sources_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_history_task_id_scraping_tasks_id_fk": {
+          "name": "scrape_history_task_id_scraping_tasks_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "scraping_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraper_download_logs": {
+      "name": "scraper_download_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scraper_download_logs_file_path_unique": {
+          "name": "scraper_download_logs_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "scraper_download_logs_source_id_sources_id_fk": {
+          "name": "scraper_download_logs_source_id_sources_id_fk",
+          "tableFrom": "scraper_download_logs",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraping_tasks": {
+      "name": "scraping_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_options": {
+          "name": "download_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scraping_tasks_source_id_sources_id_fk": {
+          "name": "scraping_tasks_source_id_sources_id_fk",
+          "tableFrom": "scraping_tasks",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sources_extractor_type_gallerydl_extractor_types_id_fk": {
+          "name": "sources_extractor_type_gallerydl_extractor_types_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "gallerydl_extractor_types",
+          "columnsFrom": ["extractor_type"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twitter_users": {
+      "name": "twitter_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nick": {
+          "name": "nick",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_banner": {
+          "name": "profile_banner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favourites_count": {
+          "name": "favourites_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "friends_count": {
+          "name": "friends_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listed_count": {
+          "name": "listed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_count": {
+          "name": "media_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "statuses_count": {
+          "name": "statuses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1778116000000,
       "tag": "0002_add_fts5_search",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "6",
+      "when": 1779374203190,
+      "tag": "0003_luxuriant_hobgoblin",
+      "breakpoints": true
     }
   ]
 }

--- a/gallery-dl-default.conf
+++ b/gallery-dl-default.conf
@@ -3,7 +3,7 @@
         "shorten": false,
         "logfile": {
             "path": "./data/scrapers/gallery-dl/logs/gallery-dl.log",
-            "level": "debug"
+            "level": "info"
         },
         "#": "modify output progress to help with monitoring from application ui",
         "mode": {
@@ -17,7 +17,7 @@
 
     "extractor": {
         "base-directory": "./public/downloads",
-        "archive": "./data/scrapers/gallery-dl/archives/gallery-dl-{category}-archive.sqlite3",
+        "archive": ["./data/scrapers/gallery-dl/archives", "gallery-dl-{category}-archive.sqlite3"],
         "sleep": [5, 10],
         "sleep-request": [5, 10],
         "cookies": ["firefox"],
@@ -46,7 +46,7 @@
         "rate-limit": "5M",
         "retries": 3,
         "progress": 0,
-	    "proxy": ""
+        "proxy": ""
     },
 
     "postprocessor":

--- a/src/app/scrape/actions.ts
+++ b/src/app/scrape/actions.ts
@@ -1,5 +1,6 @@
 "use server";
 
+import fs from "node:fs";
 import { and, desc, eq, isNull } from "drizzle-orm";
 import { revalidatePath } from "next/cache";
 import { paths } from "@/lib/config";
@@ -157,6 +158,25 @@ export async function getScrapeHistory(limit = 50) {
   });
 }
 
+const CURSOR_RE = /Use '-o cursor=([^']+)' to continue/;
+
+/**
+ * Try to extract a gallery-dl resume cursor from a log file.
+ * Returns the last cursor found (most recent hint), or null.
+ */
+function extractCursorFromLog(logPath: string): string | null {
+  try {
+    if (!fs.existsSync(logPath)) return null;
+
+    const content = fs.readFileSync(logPath, "utf-8");
+    const matches = [...content.matchAll(new RegExp(CURSOR_RE.source, "g"))];
+    if (matches.length === 0) return null;
+    return matches[matches.length - 1][1];
+  } catch {
+    return null;
+  }
+}
+
 export async function resumeFromHistory(historyId: number) {
   const history = await db.query.scrapeHistory.findFirst({
     where: eq(scrapeHistory.id, historyId),
@@ -170,12 +190,25 @@ export async function resumeFromHistory(historyId: number) {
     throw new Error("History record not found");
   }
 
-  if (!history.cursor) {
-    throw new Error("No cursor available for this history record");
-  }
-
   if (!history.source) {
     throw new Error("Source not found");
+  }
+
+  // Use stored cursor, or fall back to extracting from the log file
+  let cursor = history.cursor;
+  if (!cursor && history.logPath) {
+    cursor = extractCursorFromLog(history.logPath);
+    if (cursor) {
+      // Backfill the DB so we don't need to re-read the log next time
+      await db
+        .update(scrapeHistory)
+        .set({ cursor })
+        .where(eq(scrapeHistory.id, historyId));
+    }
+  }
+
+  if (!cursor) {
+    throw new Error("No cursor available for this history record");
   }
 
   const tool = "gallery-dl";
@@ -187,7 +220,7 @@ export async function resumeFromHistory(historyId: number) {
     paths.downloads,
     {
       taskId: history.taskId ?? undefined,
-      cursor: history.cursor,
+      cursor,
     },
   );
 

--- a/src/app/scrape/actions.ts
+++ b/src/app/scrape/actions.ts
@@ -86,6 +86,7 @@ export async function toggleTaskSchedule(id: number, enabled: boolean) {
 export async function runTaskNow(
   taskId: number,
   mode: "full" | "quick" = "full",
+  cursor?: string,
 ) {
   const task = await db.query.scrapingTasks.findFirst({
     where: eq(scrapingTasks.id, taskId),
@@ -121,6 +122,7 @@ export async function runTaskNow(
       mode: mode, // Use the provided mode
       taskId: task.id,
       limits: task.downloadOptions || undefined,
+      cursor: cursor,
     },
   );
 
@@ -153,6 +155,43 @@ export async function getScrapeHistory(limit = 50) {
       task: true,
     },
   });
+}
+
+export async function resumeFromHistory(historyId: number) {
+  const history = await db.query.scrapeHistory.findFirst({
+    where: eq(scrapeHistory.id, historyId),
+    with: {
+      source: true,
+      task: true,
+    },
+  });
+
+  if (!history) {
+    throw new Error("History record not found");
+  }
+
+  if (!history.cursor) {
+    throw new Error("No cursor available for this history record");
+  }
+
+  if (!history.source) {
+    throw new Error("Source not found");
+  }
+
+  const tool = "gallery-dl";
+
+  await scraperManager.startScrape(
+    history.sourceId,
+    tool,
+    history.source.url,
+    paths.downloads,
+    {
+      taskId: history.taskId ?? undefined,
+      cursor: history.cursor,
+    },
+  );
+
+  revalidatePath("/scrape");
 }
 
 // Helper to get all sources for the dropdown

--- a/src/app/scrape/history-table.tsx
+++ b/src/app/scrape/history-table.tsx
@@ -1,10 +1,12 @@
 "use client";
 
 import { formatDistanceToNow } from "date-fns";
+import { RotateCcw } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import {
   getActiveScrapeStatuses,
   getScrapeHistory,
+  resumeFromHistory,
 } from "@/app/scrape/actions";
 import styles from "@/app/scrape/page.module.css";
 
@@ -18,6 +20,9 @@ interface HistoryItem {
   postsProcessed: number | null;
   bytesDownloaded: number | null;
   errorCount: number | null;
+  cursor: string | null;
+  sourceId: number;
+  taskId: number | null;
 }
 
 export default function ScrapeHistoryTable({
@@ -46,6 +51,9 @@ export default function ScrapeHistoryTable({
           postsProcessed: h.postsProcessed as number | null,
           bytesDownloaded: h.bytesDownloaded as number | null,
           errorCount: h.errorCount as number | null,
+          cursor: (h.cursor as string) || null,
+          sourceId: h.sourceId as number,
+          taskId: (h.taskId as number) || null,
         }),
       );
       setHistoryItems(mapped);
@@ -114,6 +122,15 @@ export default function ScrapeHistoryTable({
     return `${parseFloat((bytes / k ** i).toFixed(2))} ${sizes[i]}`;
   };
 
+  const handleResume = async (historyId: number) => {
+    try {
+      await resumeFromHistory(historyId);
+    } catch (error) {
+      console.error("Failed to resume scrape:", error);
+      alert("Failed to resume scrape");
+    }
+  };
+
   return (
     <div className={styles.listContainer}>
       <table className={styles.table}>
@@ -127,6 +144,7 @@ export default function ScrapeHistoryTable({
             <th className={styles.thRight}>Skipped</th>
             <th className={styles.thRight}>Size</th>
             <th className={styles.thRight}>Errors</th>
+            <th>Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -169,11 +187,23 @@ export default function ScrapeHistoryTable({
               >
                 {item.errorCount}
               </td>
+              <td>
+                {item.status === "failed" && item.cursor && (
+                  <button
+                    type="button"
+                    onClick={() => handleResume(item.id)}
+                    className={styles.iconButton}
+                    title={`Resume from cursor: ${item.cursor}`}
+                  >
+                    <RotateCcw size={14} />
+                  </button>
+                )}
+              </td>
             </tr>
           ))}
           {historyItems.length === 0 && (
             <tr>
-              <td colSpan={8} className={styles.emptyCell}>
+              <td colSpan={9} className={styles.emptyCell}>
                 No history available.
               </td>
             </tr>

--- a/src/app/scrape/history-table.tsx
+++ b/src/app/scrape/history-table.tsx
@@ -161,7 +161,7 @@ export default function ScrapeHistoryTable({
                     {Math.round(
                       (new Date(item.endTime).getTime() -
                         new Date(item.startTime).getTime()) /
-                        1000,
+                      1000,
                     )}
                     s
                   </span>
@@ -188,12 +188,16 @@ export default function ScrapeHistoryTable({
                 {item.errorCount}
               </td>
               <td>
-                {item.status === "failed" && item.cursor && (
+                {item.status === "failed" && (
                   <button
                     type="button"
                     onClick={() => handleResume(item.id)}
                     className={styles.iconButton}
-                    title={`Resume from cursor: ${item.cursor}`}
+                    title={
+                      item.cursor
+                        ? `Resume from cursor: ${item.cursor}`
+                        : "Try to resume from log file"
+                    }
                   >
                     <RotateCcw size={14} />
                   </button>

--- a/src/app/scrape/history-table.tsx
+++ b/src/app/scrape/history-table.tsx
@@ -161,7 +161,7 @@ export default function ScrapeHistoryTable({
                     {Math.round(
                       (new Date(item.endTime).getTime() -
                         new Date(item.startTime).getTime()) /
-                      1000,
+                        1000,
                     )}
                     s
                   </span>

--- a/src/app/scrape/page-client.tsx
+++ b/src/app/scrape/page-client.tsx
@@ -35,6 +35,9 @@ export default function ScrapePageClient({
     postsProcessed: number | null;
     bytesDownloaded: number | null;
     errorCount: number | null;
+    cursor: string | null;
+    sourceId: number;
+    taskId: number | null;
   }[];
 }) {
   const [activeTab, setActiveTab] = useState<"tasks" | "history">("tasks");

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -76,6 +76,7 @@ export const scrapeHistory = sqliteTable("scrape_history", {
   averageSpeed: integer("average_speed").default(0), // bytes per second
   lastError: text("last_error"),
   logPath: text("log_path"),
+  cursor: text("cursor"), // gallery-dl resume cursor for continuing failed scrapes
   taskId: integer("task_id").references(() => scrapingTasks.id, {
     onDelete: "set null",
   }),

--- a/src/lib/scrapers/manager.ts
+++ b/src/lib/scrapers/manager.ts
@@ -19,6 +19,7 @@ export interface ScrapingStatus extends ScrapeProgress {
   taskId?: number;
   logPath?: string;
   lastDbUpdate?: number;
+  resumeCursor?: string;
 }
 
 class ScraperManager {
@@ -78,6 +79,7 @@ class ScraperManager {
       mode?: "full" | "quick";
       taskId?: number;
       limits?: ScrapeLimits;
+      cursor?: string;
     } = {},
   ) {
     console.log(
@@ -146,6 +148,7 @@ class ScraperManager {
       isRateLimited: false,
       isFinished: false,
       logPath,
+      resumeCursor: options.cursor,
     };
 
     const { promise, child, strategy } = runner.run(
@@ -154,6 +157,7 @@ class ScraperManager {
         url,
         logPath: logPath,
         mode: options.mode,
+        cursor: options.cursor,
         onProgress: (p) => {
           const current = this.activeScrapes.get(sourceId);
           if (current) {
@@ -272,6 +276,7 @@ class ScraperManager {
               averageSpeed,
               lastError:
                 result.error || (result.success ? null : result.output),
+              cursor: result.cursor || current.status.cursor || null,
             })
             .where(eq(scrapeHistory.id, historyId));
 

--- a/src/lib/scrapers/strategies/base.ts
+++ b/src/lib/scrapers/strategies/base.ts
@@ -20,6 +20,7 @@ export abstract class BaseScraperStrategy {
   public isRateLimited = false;
   public postsProcessed = 0;
   public intentionalStop = false;
+  public lastCursor: string | undefined;
 
   public processedFilesSet = new Set<string>();
   public processedFiles: string[] = [];
@@ -51,6 +52,11 @@ export abstract class BaseScraperStrategy {
     if (line.includes("[post-complete]")) {
       this.postsProcessed++;
     }
+    // Parse cursor hint from gallery-dl: "Use '-o cursor=XXXXX' to continue"
+    const cursorMatch = line.match(/Use '-o cursor=([^']+)' to continue/);
+    if (cursorMatch) {
+      this.lastCursor = cursorMatch[1];
+    }
   }
 
   protected triggerOnProgress(child: ChildProcess) {
@@ -65,6 +71,7 @@ export abstract class BaseScraperStrategy {
         postsProcessed: this.postsProcessed,
         isRateLimited: this.isRateLimited,
         isFinished: false,
+        cursor: this.lastCursor,
       });
 
       this.checkLimits(child);
@@ -129,6 +136,7 @@ export abstract class BaseScraperStrategy {
         postsProcessed: this.postsProcessed,
         isRateLimited: this.isRateLimited,
         isFinished: true,
+        cursor: this.lastCursor,
       });
     }
     return {
@@ -136,6 +144,7 @@ export abstract class BaseScraperStrategy {
       output: this.stdout,
       error: errorMsg,
       items: this.processedFiles,
+      cursor: this.lastCursor,
     };
   }
 }

--- a/src/lib/scrapers/strategies/gallery-dl.ts
+++ b/src/lib/scrapers/strategies/gallery-dl.ts
@@ -32,15 +32,24 @@ export class GalleryDlStrategy extends BaseScraperStrategy {
     // postprocessor in gallery-dl.conf for better reliability.
 
     // Override archive path so dedup DBs live in DATA_DIR regardless of CWD
-    args.push(
-      "-o",
-      `extractor.archive=${path.join(paths.galleryDl.archives, "gallery-dl-{category}-archive.sqlite3")}`,
-    );
+    // gallery-dl requires a list format for archive paths with format fields.
+    // Each element is a path component; the first starting with "/" is the root.
+    // {category} is expanded per-extractor by gallery-dl's format engine.
+    const archiveSegments = [
+      paths.galleryDl.archives,
+      "gallery-dl-{category}-archive.sqlite3",
+    ];
+    args.push("-o", `extractor.archive=${JSON.stringify(archiveSegments)}`);
 
     // Log file overrides
     if (this.options.logPath) {
       args.push("-o", `output.logfile.path=${this.options.logPath}`);
-      args.push("-o", "output.logfile.level=debug");
+      args.push("-o", "output.logfile.level=info");
+    }
+
+    // Resume cursor (e.g. pixiv offset for continuing failed scrapes)
+    if (this.options.cursor) {
+      args.push("-o", `cursor=${this.options.cursor}`);
     }
 
     args.push("--destination", this.basePath);

--- a/src/lib/scrapers/types.ts
+++ b/src/lib/scrapers/types.ts
@@ -7,6 +7,7 @@ export interface ScrapeProgress {
   postsProcessed: number;
   isRateLimited: boolean;
   isFinished: boolean;
+  cursor?: string; // gallery-dl resume cursor (e.g. pixiv offset)
 }
 
 export interface ScrapeResult {
@@ -14,6 +15,7 @@ export interface ScrapeResult {
   output: string; // JSON or raw output
   error?: string;
   items: string[]; // List of absolute file paths processed/downloaded
+  cursor?: string; // Resume cursor from gallery-dl
 }
 
 // Legacy, keeping just in case
@@ -31,5 +33,6 @@ export interface ScraperOptions {
   downloadPath?: string;
   logPath?: string;
   mode?: "full" | "quick";
+  cursor?: string;
   onProgress?: (progress: ScrapeProgress) => void;
 }


### PR DESCRIPTION
Cursor-based resume added to scrape history records

Also, fixed archive path format for gallery-dl versions >= 1.29

Removed debug traces from production