### PR TITLE
fix: mobile lightbox info toggles

### DIFF
--- a/src/components/Lightbox.module.css
+++ b/src/components/Lightbox.module.css
@@ -37,14 +37,18 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  pointer-events: none;
 }
 
 .image {
+  width: auto;
+  height: auto;
   max-width: 100%;
   max-height: 100%;
   object-fit: contain;
   box-shadow: 0 0 50px rgba(0, 0, 0, 0.5);
   transition: transform 0.3s ease;
+  pointer-events: auto;
 }
 
 .video {
@@ -52,6 +56,7 @@
   max-height: 100%;
   outline: none;
   box-shadow: 0 0 50px rgba(0, 0, 0, 0.5);
+  pointer-events: auto;
 }
 
 .sidebar {
@@ -322,6 +327,7 @@
   border-radius: var(--radius);
   overflow-y: auto;
   max-height: 80vh;
+  pointer-events: auto;
 }
 
 .tagsContainer {
@@ -400,9 +406,11 @@
   }
 
   .controls {
+    position: fixed;
     top: 10px;
     right: 10px;
     gap: 8px;
+    z-index: 200;
   }
 
   .iconButton {

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -42,7 +42,16 @@ export default function Lightbox({
   const { item } = row;
   const [showInfo, setShowInfo] = useState(true);
   const [pixivTags, setPixivTags] = useState<{ name: string }[]>([]);
+  const [isRecentlyMounted, setIsRecentlyMounted] = useState(true);
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  // Prevent mobile click-through/ghost click events on mount
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsRecentlyMounted(false);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, []);
 
   // Touch swipe handling
   const touchStartX = useRef<number | null>(null);
@@ -172,7 +181,10 @@ export default function Lightbox({
           // If clicking the background (not the image), close?
           // Or maybe clicking image toggles sidebar?
           // Let's make clicking background close.
-          if (e.target === e.currentTarget) onClose();
+          if (e.target === e.currentTarget) {
+            if (isRecentlyMounted) return;
+            onClose();
+          }
         }}
         onKeyDown={handleKeyActivate(() => {
           if (typeof window !== "undefined") {
@@ -232,7 +244,10 @@ export default function Lightbox({
               className={styles.image}
               onClick={(e) => {
                 e.stopPropagation();
-                setShowInfo(!showInfo);
+                if (isRecentlyMounted) return;
+                if (typeof window !== "undefined" && window.innerWidth >= 768) {
+                  setShowInfo(!showInfo);
+                }
               }}
               width={1200}
               height={800}


### PR DESCRIPTION
### 1. Fixed Mount Ghost-Click / Click-Through Issue
- **Problem**: When a user tapped on a gallery item to open the lightbox in mobile view, the click event would propagate to or trigger on the newly mounted `<Image>` component, immediately toggling `showInfo` from `true` to `false` and hiding the post info sidebar on mount.
- **Solution**: Added an `isRecentlyMounted` state in `src/components/Lightbox.tsx` which is set to `true` on mount and turns to `false` after `300ms` via a `setTimeout`.
- **Implementation**: Protected the background close handler (`onClose`) and the image click handler by returning early if `isRecentlyMounted` is `true`.

### 2. Disabled Image Tap Toggling on Mobile
- **Problem**: Tapping an image in the lightbox on mobile frequently caused accidental toggles of the info pane due to pinch-zoom or swipe gestures, which was inconsistent with video playback (which didn't toggle info).
- **Solution**: Restricted the image `onClick` toggle behavior so it is only active on desktop screens (`window.innerWidth >= 768`). On mobile, the dedicated close/info/hide buttons are used exclusively.

### 3. Elevated Controls Layer & Stacking Context
- **Problem**: When the sidebar was hidden, the video element scaled to fit `100dvh`. Because mobile browsers render `<video> ` in a separate hardware overlay layer, it would intercept all touch/pointer events and prevent users from clicking the absolutely positioned `.controls` buttons to bring the sidebar back.
- **Solution**: In `src/components/Lightbox.module.css` inside the `@media (max-width: 767px)` block, we configured `.controls` with `position: fixed` and `z-index: 200`.
- **Effect**: This removes the controls from the relative flex flow, placing them in a fixed layout relative to the viewport with a high stacking priority so they always float on top and are perfectly clickable.

### 4. Image Aspect Ratio DOM Shrink-Wrapping & Shadow Precision
- **Problem**: The Next.js `<Image>` attributes default the element's layout to a `1200x800` (landscape) aspect ratio. For highly vertical or very wide images, the `<img>` DOM node occupied a huge invisible box. The drop-shadow (`box-shadow`) was rendered around this empty landscape box instead of the visible image bounds.
- **Solution**: Added `width: auto` and `height: auto` to `.image` in `src/components/Lightbox.module.css`.
- **Effect**: The `<img>` DOM boundaries now precisely shrink-wrap the visible bounds of the image, correcting the drop-shadow rendering and ensuring there is no empty space blocking background clicks.

### 5. Improved Click-Through and Usability for Background Close
- **Problem**: The absolute-positioned `.mediaWrapper` container absorbed clicks in empty space around the centered media and prevented the parent `.mainArea`'s click handler from closing the lightbox.
- **Solution**: Added `pointer-events: none` on `.mediaWrapper`, and `pointer-events: auto` on `.image`, `.video`, and `.textContent`.
- **Effect**: Tapping empty space now passes through directly to `.mainArea`, allowing the lightbox to close smoothly.

Also fixes #44 