### PR TITLE
feat: loop video playback by default, add setting to toggle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -225,4 +225,15 @@ Playwright E2E tests for settings, scrapers, and purging interact with a single 
 
 - **Rule**: E2E test runs (specifically those modifying system configuration or purging database records) must be executed sequentially. Ensure `--workers=1` or `npx playwright test --workers=1` is specified when running the E2E suites.
 
+### 3.6 Docker Compose for Playwright E2E Tests
+
+When running E2E tests locally, Playwright targets the server hosted by the Docker test compose stack on port 3001 (configured in `compose.test.yaml`). Because Playwright connects to this pre-built production container, any changes made to the source code will not be reflected in E2E tests until the test container is rebuilt and restarted.
+
+- **Rule**: Before executing E2E tests to verify new or modified code, you MUST recompose the test stack:
+  ```bash
+  docker compose -f compose.test.yaml up --build -d
+  ```
+  Wait for the build to complete and the container to be healthy before running the E2E tests.
+
 ---
+

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -23,6 +23,7 @@ export default function GalleryPageClient({
   initialNextCursor,
   pageSize,
   scrollMode,
+  loopVideos,
 }: {
   initialItems: GalleryGroup[];
   initialSearch: string;
@@ -30,6 +31,7 @@ export default function GalleryPageClient({
   initialNextCursor: string | null;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  loopVideos: boolean;
 }) {
   return (
     <GalleryPageContent
@@ -39,6 +41,7 @@ export default function GalleryPageClient({
       initialNextCursor={initialNextCursor}
       pageSize={pageSize}
       scrollMode={scrollMode}
+      loopVideos={loopVideos}
     />
   );
 }
@@ -50,6 +53,7 @@ function GalleryPageContent({
   initialNextCursor,
   pageSize,
   scrollMode,
+  loopVideos,
 }: {
   initialItems: GalleryGroup[];
   initialSearch: string;
@@ -57,6 +61,7 @@ function GalleryPageContent({
   initialNextCursor: string | null;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  loopVideos: boolean;
 }) {
   const [columnCount, setColumnCount] = useState(4);
   const [deleting, setDeleting] = useState(false);
@@ -253,6 +258,7 @@ function GalleryPageContent({
           onNext={nextLightbox}
           onPrev={prevLightbox}
           onDelete={handleDeleteItem}
+          loopVideos={loopVideos}
         />
       )}
     </div>

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -34,6 +34,7 @@ export default async function GalleryPage({
       initialNextCursor={nextCursor}
       pageSize={limit}
       scrollMode={scrollMode}
+      loopVideos={settings.loopVideos}
     />
   );
 }

--- a/src/app/settings/page-client.tsx
+++ b/src/app/settings/page-client.tsx
@@ -4,6 +4,7 @@ import {
   AlertCircle,
   CheckCircle,
   Globe,
+  Play,
   RotateCcw,
   Save,
   Settings as SettingsIcon,
@@ -363,6 +364,38 @@ export default function SettingsPageClient({
                     Use 0 to disable cleanup.
                   </p>
                 </div>
+              </div>
+
+              <h2 className={styles.sectionTitle}>
+                <Play size={18} />
+                <span>Playback & Media</span>
+              </h2>
+
+              <div
+                className={styles.toggleContainer}
+                style={{ marginBottom: "2rem" }}
+              >
+                <div className={styles.toggleInfo}>
+                  <span className={styles.toggleTitle}>
+                    Loop Videos by Default
+                  </span>
+                  <span className={styles.toggleDescription}>
+                    Automatically loop video clips when playing them in the
+                    gallery lightbox and timeline.
+                  </span>
+                </div>
+                <label className={styles.switch} htmlFor="loopVideos">
+                  <input
+                    id="loopVideos"
+                    aria-label="Loop Videos by Default"
+                    type="checkbox"
+                    checked={settings.app.loopVideos}
+                    onChange={(e) =>
+                      handleAppChange("loopVideos", e.target.checked)
+                    }
+                  />
+                  <span className={styles.slider} />
+                </label>
               </div>
 
               <h2 className={styles.sectionTitle}>

--- a/src/app/timeline/components/PostCard.tsx
+++ b/src/app/timeline/components/PostCard.tsx
@@ -15,12 +15,14 @@ interface PostCardProps {
     mediaIndex: number,
     e: React.MouseEvent,
   ) => void;
+  loopVideos?: boolean;
 }
 
 export default function PostCard({
   post,
   postIndex,
   onMediaClick,
+  loopVideos,
 }: PostCardProps) {
   return (
     <article className={styles.postCard}>
@@ -145,7 +147,12 @@ export default function PostCard({
               >
                 {media.type === "video" ? (
                   // biome-ignore lint/a11y/useMediaCaption: User generated content does not have captions
-                  <video src={media.url} controls className={styles.media} />
+                  <video
+                    src={media.url}
+                    controls
+                    loop={loopVideos}
+                    className={styles.media}
+                  />
                 ) : (
                   <Image
                     src={media.url}

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -24,6 +24,7 @@ export default function TimelinePageClient({
   initialSort,
   pageSize,
   scrollMode,
+  loopVideos,
 }: {
   initialPosts: TimelinePost[];
   initialNextCursor: string | null;
@@ -31,6 +32,7 @@ export default function TimelinePageClient({
   initialSort: string;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  loopVideos: boolean;
 }) {
   return (
     <TimelinePageContent
@@ -40,6 +42,7 @@ export default function TimelinePageClient({
       initialSort={initialSort}
       pageSize={pageSize}
       scrollMode={scrollMode}
+      loopVideos={loopVideos}
     />
   );
 }
@@ -51,6 +54,7 @@ function TimelinePageContent({
   initialSort,
   pageSize,
   scrollMode,
+  loopVideos,
 }: {
   initialPosts: TimelinePost[];
   initialNextCursor: string | null;
@@ -58,6 +62,7 @@ function TimelinePageContent({
   initialSort: string;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  loopVideos: boolean;
 }) {
   const {
     items: posts,
@@ -216,6 +221,7 @@ function TimelinePageContent({
             post={post}
             postIndex={postIdx}
             onMediaClick={openLightbox}
+            loopVideos={loopVideos}
           />
         ))}
 
@@ -250,6 +256,7 @@ function TimelinePageContent({
           onNext={nextLightbox}
           onPrev={prevLightbox}
           onDelete={undefined}
+          loopVideos={loopVideos}
         />
       )}
     </div>

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -37,6 +37,7 @@ export default async function TimelinePage({
       initialSort={sortBy}
       pageSize={limit}
       scrollMode={scrollMode}
+      loopVideos={settings.loopVideos}
     />
   );
 }

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -25,6 +25,7 @@ interface LightboxProps {
   onNext?: () => void;
   onPrev?: () => void;
   onDelete?: (id: number, deleteFile: boolean) => void;
+  loopVideos?: boolean;
 }
 
 export default function Lightbox({
@@ -38,6 +39,7 @@ export default function Lightbox({
   onNext,
   onPrev,
   onDelete,
+  loopVideos,
 }: LightboxProps) {
   const { item } = row;
   const [showInfo, setShowInfo] = useState(true);
@@ -217,6 +219,7 @@ export default function Lightbox({
               src={item.filePath}
               className={styles.video}
               controls
+              loop={loopVideos}
               onClick={(e) => e.stopPropagation()}
             />
           ) : item.mediaType === "text" ? (

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -22,7 +22,14 @@ export async function getSettings(): Promise<SystemSettings> {
   try {
     if (existsSync(SETTINGS_FILE_PATH)) {
       const data = await fs.readFile(SETTINGS_FILE_PATH, "utf-8");
-      return JSON.parse(data) as SystemSettings;
+      const parsed = JSON.parse(data) as SystemSettings;
+
+      // Perform a shallow merge of settings groups to support schema evolution
+      const merged: SystemSettings = {
+        app: { ...DEFAULT_SETTINGS.app, ...parsed.app },
+        scraper: { ...DEFAULT_SETTINGS.scraper, ...parsed.scraper },
+      };
+      return merged;
     }
   } catch (error) {
     console.error("[Settings] Failed to read settings.json:", error);

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -5,6 +5,7 @@ export interface AppSettings {
   scrollMode: "infinite" | "button";
   scrapeLogRetentionDays: number;
   enableProductionDestructiveOps: boolean;
+  loopVideos: boolean;
 }
 
 export interface ScraperSettings {
@@ -38,6 +39,7 @@ export const DEFAULT_SETTINGS: SystemSettings = {
     scrollMode: "infinite",
     scrapeLogRetentionDays: 30,
     enableProductionDestructiveOps: false,
+    loopVideos: true,
   },
   scraper: {
     rateLimit: "5M",

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -60,6 +60,16 @@ test.describe
       await expect(scrollModeSelect).toBeAttached();
       await scrollModeSelect.selectOption("button");
 
+      // Verify and toggle "Loop Videos by Default" (should be true initially)
+      const loopVideosToggle = page.locator("#loopVideos").first();
+      await expect(loopVideosToggle).toBeAttached();
+      const initialLoopChecked = await loopVideosToggle.isChecked();
+      expect(initialLoopChecked).toBe(true);
+
+      const loopToggleLabel = page.locator("label[for='loopVideos']").first();
+      await loopToggleLabel.click();
+      expect(await loopVideosToggle.isChecked()).toBe(false);
+
       // Toggle Destructive Ops in Production by clicking its visible switch label wrapper
       const destructiveOpsToggle = page
         .locator("#enableProductionDestructiveOps")
@@ -94,6 +104,7 @@ test.describe
       // Verify values are preserved
       await expect(page.locator("#galleryPageSize").first()).toHaveValue("125");
       await expect(page.locator("#scrollMode").first()).toHaveValue("button");
+      expect(await page.locator("#loopVideos").first().isChecked()).toBe(false);
       expect(
         await page
           .locator("#enableProductionDestructiveOps")
@@ -224,6 +235,7 @@ test.describe
         "Reset settings in form. Click 'Save Changes' to commit.",
       );
       await expect(galleryPageSizeInput).toHaveValue("50"); // Default value
+      await expect(page.locator("#loopVideos").first()).toBeChecked(); // Reset to default true
 
       // Save Changes to actually persist the default reset
       await page.getByRole("button", { name: "Save Changes" }).first().click();
@@ -235,5 +247,6 @@ test.describe
       await page.reload();
       await expect(page.getByTestId("loading-skeleton")).toBeHidden();
       await expect(page.locator("#galleryPageSize").first()).toHaveValue("50");
+      await expect(page.locator("#loopVideos").first()).toBeChecked();
     });
   });


### PR DESCRIPTION
We have successfully resolved issue #59: "Loop videos/animations by default when played." The implementation enables videos to loop continuously by default inside both the Timeline and the full-screen Lightbox viewer. It also introduces a "Loop Videos by Default" user preference toggle under System Settings.

---

## Summary of Changes

We made changes across the settings subsystem, core display components, page-level routing/data-flow, and the E2E test suite:

### 1. Settings Schema & Evolution
- **[types/settings.ts]**: Added `loopVideos: boolean` to the `AppSettings` interface and defaulted it to `true` in `DEFAULT_SETTINGS.app`.
- **[lib/settings.ts]**: Implemented a defensive shallow merge in `getSettings()` to handle older/existing `settings.json` files on disk smoothly:
  ```ts
  const merged: SystemSettings = {
    app: { ...DEFAULT_SETTINGS.app, ...parsed.app },
    scraper: { ...DEFAULT_SETTINGS.scraper, ...parsed.scraper },
  };
  ```

### 2. Playback & Media Settings UI Toggle
- **[page-client.tsx]**: 
  - Imported the `Play` icon from `lucide-react`.
  - Added a premium **Playback & Media** section containing the "Loop Videos by Default" toggle styled to match the existing switches in the settings panel.

### 3. Component & Video Tag Binding
- **[Lightbox.tsx]**: Added `loopVideos` prop and bound it to the `<video>` element's `loop` attribute.
- **[PostCard.tsx]**: Added `loopVideos` prop and bound it to the `<video>` element's `loop` attribute in the timeline feed.

### 4. Page Routing & Data-Flow Integration
- **[page.tsx]** & **[page-client.tsx]**: Loaded `loopVideos` setting on the server and passed it down to the Lightbox in the gallery view.
- **[page.tsx]** & **[page-client.tsx]**: Loaded `loopVideos` setting on the server and passed it down to both individual timeline `PostCard` elements and the Lightbox viewer.

### 5. Contributor & System Documentation
- **[CONTRIBUTING.md]**: Documented the Docker Compose/Podman test container rebuild requirement in a new Section 3.6 so that future developers know to recompose the stack before testing new changes.
