### PR TITLE
80 autoplay videos

### DIFF
--- a/src/app/gallery/components/GalleryItem.tsx
+++ b/src/app/gallery/components/GalleryItem.tsx
@@ -2,6 +2,7 @@
 
 import Image from "next/image";
 import styles from "@/app/gallery/page.module.css";
+import { useAutoplayVideo } from "@/hooks/useAutoplayVideo";
 import { handleKeyActivate } from "@/lib/utils/a11y";
 import type { GalleryGroup } from "@/types/media";
 
@@ -9,6 +10,8 @@ interface GalleryItemProps {
   row: GalleryGroup;
   isSelected: boolean;
   selectionMode: boolean;
+  autoplayVideos: boolean;
+  muteAutoplayVideos: boolean;
   onClick: () => void;
 }
 
@@ -16,10 +19,13 @@ export default function GalleryItem({
   row,
   isSelected,
   selectionMode,
+  autoplayVideos,
+  muteAutoplayVideos,
   onClick,
 }: GalleryItemProps) {
   const item = row.item;
   const count = row.groupCount || 1;
+  const videoRef = useAutoplayVideo(autoplayVideos, muteAutoplayVideos);
 
   const handleVideoPlay = async (target: HTMLVideoElement) => {
     try {
@@ -58,15 +64,20 @@ export default function GalleryItem({
       {item.mediaType === "video" ? (
         <>
           <video
+            ref={videoRef}
             src={item.filePath}
             className={styles.media}
             muted
             loop
             tabIndex={0}
-            onMouseOver={(e) => handleVideoPlay(e.currentTarget)}
-            onMouseOut={(e) => handleVideoPause(e.currentTarget)}
-            onFocus={(e) => handleVideoPlay(e.currentTarget)}
-            onBlur={(e) => handleVideoPause(e.currentTarget)}
+            onMouseOver={(e) =>
+              !autoplayVideos && handleVideoPlay(e.currentTarget)
+            }
+            onMouseOut={(e) =>
+              !autoplayVideos && handleVideoPause(e.currentTarget)
+            }
+            onFocus={(e) => !autoplayVideos && handleVideoPlay(e.currentTarget)}
+            onBlur={(e) => !autoplayVideos && handleVideoPause(e.currentTarget)}
           />
           <div className={styles.videoBadge}>VIDEO</div>
         </>

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -25,6 +25,8 @@ export default function GalleryPageClient({
   pageSize,
   scrollMode,
   loopVideos,
+  autoplayVideos,
+  muteAutoplayVideos,
   playlistId,
 }: {
   initialItems: GalleryGroup[];
@@ -34,6 +36,8 @@ export default function GalleryPageClient({
   pageSize: number;
   scrollMode: "infinite" | "button";
   loopVideos: boolean;
+  autoplayVideos: boolean;
+  muteAutoplayVideos: boolean;
   playlistId?: number;
 }) {
   return (
@@ -45,6 +49,8 @@ export default function GalleryPageClient({
       pageSize={pageSize}
       scrollMode={scrollMode}
       loopVideos={loopVideos}
+      autoplayVideos={autoplayVideos}
+      muteAutoplayVideos={muteAutoplayVideos}
       playlistId={playlistId}
     />
   );
@@ -58,6 +64,8 @@ function GalleryPageContent({
   pageSize,
   scrollMode,
   loopVideos,
+  autoplayVideos,
+  muteAutoplayVideos,
   playlistId,
 }: {
   initialItems: GalleryGroup[];
@@ -67,6 +75,8 @@ function GalleryPageContent({
   pageSize: number;
   scrollMode: "infinite" | "button";
   loopVideos: boolean;
+  autoplayVideos: boolean;
+  muteAutoplayVideos: boolean;
   playlistId?: number;
 }) {
   const [columnCount, setColumnCount] = useState(4);
@@ -193,6 +203,8 @@ function GalleryPageContent({
             row={row}
             isSelected={row.groupItems.some((i) => selectedIds.has(i.item.id))}
             selectionMode={selectionMode}
+            autoplayVideos={autoplayVideos}
+            muteAutoplayVideos={muteAutoplayVideos}
             onClick={() => {
               if (selectionMode) {
                 toggleGroupSelection(

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -44,6 +44,8 @@ export default async function GalleryPage({
       pageSize={limit}
       scrollMode={scrollMode}
       loopVideos={settings.loopVideos}
+      autoplayVideos={settings.autoplayVideos ?? false}
+      muteAutoplayVideos={settings.muteAutoplayVideos ?? true}
       playlistId={
         playlistId && !Number.isNaN(playlistId) ? playlistId : undefined
       }

--- a/src/app/settings/page-client.tsx
+++ b/src/app/settings/page-client.tsx
@@ -452,7 +452,7 @@ export default function SettingsPageClient({
 
               <div
                 className={styles.toggleContainer}
-                style={{ marginBottom: "2rem" }}
+                style={{ marginBottom: "1.5rem" }}
               >
                 <div className={styles.toggleInfo}>
                   <span className={styles.toggleTitle}>
@@ -471,6 +471,67 @@ export default function SettingsPageClient({
                     checked={settings.app.loopVideos}
                     onChange={(e) =>
                       handleAppChange("loopVideos", e.target.checked)
+                    }
+                  />
+                  <span className={styles.slider} />
+                </label>
+              </div>
+
+              <div
+                className={styles.toggleContainer}
+                style={{ marginBottom: "1.5rem" }}
+              >
+                <div className={styles.toggleInfo}>
+                  <span className={styles.toggleTitle}>
+                    Autoplay Videos on Scroll
+                  </span>
+                  <span className={styles.toggleDescription}>
+                    Automatically play video clips when they are scrolled into
+                    view in the gallery grid and timeline.
+                  </span>
+                </div>
+                <label className={styles.switch} htmlFor="autoplayVideos">
+                  <input
+                    id="autoplayVideos"
+                    aria-label="Autoplay Videos on Scroll"
+                    type="checkbox"
+                    checked={settings.app.autoplayVideos}
+                    onChange={(e) =>
+                      handleAppChange("autoplayVideos", e.target.checked)
+                    }
+                  />
+                  <span className={styles.slider} />
+                </label>
+              </div>
+
+              <div
+                className={styles.toggleContainer}
+                style={{
+                  marginBottom: "2rem",
+                  opacity: settings.app.autoplayVideos ? 1 : 0.5,
+                  transition: "opacity 0.2s ease-in-out",
+                  pointerEvents: settings.app.autoplayVideos ? "auto" : "none",
+                }}
+              >
+                <div className={styles.toggleInfo}>
+                  <span className={styles.toggleTitle}>
+                    Mute Autoplayed Videos
+                  </span>
+                  <span className={styles.toggleDescription}>
+                    Mute videos when autoplaying to avoid overlapping audio
+                    sources. Turning this off may be blocked by browser autoplay
+                    policies.
+                  </span>
+                </div>
+                <label className={styles.switch} htmlFor="muteAutoplayVideos">
+                  <input
+                    id="muteAutoplayVideos"
+                    aria-label="Mute Autoplayed Videos"
+                    type="checkbox"
+                    checked={settings.app.muteAutoplayVideos}
+                    disabled={!settings.app.autoplayVideos}
+                    onChange={(e) =>
+                      handleAppChange("muteAutoplayVideos", e.target.checked)
                     }
                   />
                   <span className={styles.slider} />

--- a/src/app/timeline/components/PostCard.tsx
+++ b/src/app/timeline/components/PostCard.tsx
@@ -5,6 +5,7 @@ import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import styles from "@/app/timeline/page.module.css";
 import FormattedContent from "@/components/FormattedContent";
+import { useAutoplayVideo } from "@/hooks/useAutoplayVideo";
 import { handleKeyActivate } from "@/lib/utils/a11y";
 import type { TimelinePost } from "@/types/posts";
 
@@ -17,6 +18,8 @@ interface PostCardProps {
     e: React.MouseEvent,
   ) => void;
   loopVideos?: boolean;
+  autoplayVideos?: boolean;
+  muteAutoplayVideos?: boolean;
   condensePostText?: boolean;
   condensePostLines?: number;
 }
@@ -26,6 +29,8 @@ export default function PostCard({
   postIndex,
   onMediaClick,
   loopVideos,
+  autoplayVideos = false,
+  muteAutoplayVideos = true,
   condensePostText = true,
   condensePostLines = 2,
 }: PostCardProps) {
@@ -198,12 +203,11 @@ export default function PostCard({
                 tabIndex={0}
               >
                 {media.type === "video" ? (
-                  // biome-ignore lint/a11y/useMediaCaption: User generated content does not have captions
-                  <video
+                  <PostVideo
                     src={media.url}
-                    controls
-                    loop={loopVideos}
-                    className={styles.media}
+                    loop={!!loopVideos}
+                    autoplayEnabled={!!autoplayVideos}
+                    muteEnabled={!!muteAutoplayVideos}
                   />
                 ) : (
                   <Image
@@ -231,5 +235,32 @@ export default function PostCard({
         </div>
       )}
     </article>
+  );
+}
+
+interface PostVideoProps {
+  src: string;
+  loop: boolean;
+  autoplayEnabled: boolean;
+  muteEnabled: boolean;
+}
+
+function PostVideo({
+  src,
+  loop,
+  autoplayEnabled,
+  muteEnabled,
+}: PostVideoProps) {
+  const videoRef = useAutoplayVideo(autoplayEnabled, muteEnabled);
+
+  return (
+    // biome-ignore lint/a11y/useMediaCaption: User generated content does not have captions
+    <video
+      ref={videoRef}
+      src={src}
+      controls
+      loop={loop}
+      className={styles.media}
+    />
   );
 }

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -25,6 +25,8 @@ export default function TimelinePageClient({
   pageSize,
   scrollMode,
   loopVideos,
+  autoplayVideos,
+  muteAutoplayVideos,
   condensePostText,
   condensePostLines,
 }: {
@@ -35,6 +37,8 @@ export default function TimelinePageClient({
   pageSize: number;
   scrollMode: "infinite" | "button";
   loopVideos: boolean;
+  autoplayVideos: boolean;
+  muteAutoplayVideos: boolean;
   condensePostText: boolean;
   condensePostLines: number;
 }) {
@@ -47,6 +51,8 @@ export default function TimelinePageClient({
       pageSize={pageSize}
       scrollMode={scrollMode}
       loopVideos={loopVideos}
+      autoplayVideos={autoplayVideos}
+      muteAutoplayVideos={muteAutoplayVideos}
       condensePostText={condensePostText}
       condensePostLines={condensePostLines}
     />
@@ -61,6 +67,8 @@ function TimelinePageContent({
   pageSize,
   scrollMode,
   loopVideos,
+  autoplayVideos,
+  muteAutoplayVideos,
   condensePostText,
   condensePostLines,
 }: {
@@ -71,6 +79,8 @@ function TimelinePageContent({
   pageSize: number;
   scrollMode: "infinite" | "button";
   loopVideos: boolean;
+  autoplayVideos: boolean;
+  muteAutoplayVideos: boolean;
   condensePostText: boolean;
   condensePostLines: number;
 }) {
@@ -232,6 +242,8 @@ function TimelinePageContent({
             postIndex={postIdx}
             onMediaClick={openLightbox}
             loopVideos={loopVideos}
+            autoplayVideos={autoplayVideos}
+            muteAutoplayVideos={muteAutoplayVideos}
             condensePostText={condensePostText}
             condensePostLines={condensePostLines}
           />

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -18,6 +18,8 @@ export default async function TimelinePage({
   const settings = await getAppSettings();
   const limit = settings.timelinePageSize || 20;
   const scrollMode = settings.scrollMode || "infinite";
+  const autoplayVideos = settings.autoplayVideos ?? false;
+  const muteAutoplayVideos = settings.muteAutoplayVideos ?? true;
 
   // Initial data fetch — respecting configured page size
   const { posts, nextCursor } = await getTimelinePosts({
@@ -38,6 +40,8 @@ export default async function TimelinePage({
       pageSize={limit}
       scrollMode={scrollMode}
       loopVideos={settings.loopVideos}
+      autoplayVideos={autoplayVideos}
+      muteAutoplayVideos={muteAutoplayVideos}
       condensePostText={settings.condensePostText ?? true}
       condensePostLines={settings.condensePostLines ?? 2}
     />

--- a/src/hooks/useAutoplayVideo.ts
+++ b/src/hooks/useAutoplayVideo.ts
@@ -1,0 +1,68 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * A custom React hook that plays and pauses a video element automatically
+ * based on its visibility in the viewport using the IntersectionObserver API.
+ *
+ * @param autoplayEnabled - Whether autoplay behavior is turned on
+ * @param muteEnabled - Whether the video should be muted when played
+ * @returns A React Ref to be attached to the <video> element
+ */
+export function useAutoplayVideo(
+  autoplayEnabled: boolean,
+  muteEnabled: boolean,
+) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+
+  useEffect(() => {
+    if (!autoplayEnabled) {
+      return;
+    }
+
+    if (typeof window === "undefined" || !("IntersectionObserver" in window)) {
+      return;
+    }
+
+    const videoElement = videoRef.current;
+    if (!videoElement) {
+      return;
+    }
+
+    // Set initial mute state
+    videoElement.muted = muteEnabled;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+            // Apply mute state right before playing
+            videoElement.muted = muteEnabled;
+            videoElement.play().catch((err: unknown) => {
+              if (
+                err instanceof Error &&
+                err.name !== "AbortError" &&
+                err.name !== "NotAllowedError"
+              ) {
+                console.error("[useAutoplayVideo] Playback failed:", err);
+              }
+            });
+          } else {
+            videoElement.pause();
+          }
+        }
+      },
+      {
+        threshold: 0.5, // 50% or more visible
+      },
+    );
+
+    observer.observe(videoElement);
+
+    return () => {
+      observer.unobserve(videoElement);
+      observer.disconnect();
+    };
+  }, [autoplayEnabled, muteEnabled]);
+
+  return videoRef;
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -8,6 +8,8 @@ export interface AppSettings {
   loopVideos: boolean;
   condensePostText: boolean;
   condensePostLines: number;
+  autoplayVideos: boolean;
+  muteAutoplayVideos: boolean;
 }
 
 export interface ScraperSettings {
@@ -44,6 +46,8 @@ export const DEFAULT_SETTINGS: SystemSettings = {
     loopVideos: true,
     condensePostText: true,
     condensePostLines: 2,
+    autoplayVideos: false,
+    muteAutoplayVideos: true,
   },
   scraper: {
     rateLimit: "5M",


### PR DESCRIPTION
### 1. Settings Schema Expansion
We added two new options to `AppSettings` in `src/types/settings.ts` with sensible defaults:
* `autoplayVideos`: Controls whether videos autoplay when visible (`false` by default to conserve bandwidth and CPU).
* `muteAutoplayVideos`: Controls whether autoplayed videos are muted (`true` by default to avoid overlapping audio sources).

### 2. Premium Settings UI Controls
Added two beautiful form control toggles to the **Playback & Media** tab in `src/app/settings/page-client.tsx`:
* A toggle for **Autoplay Videos on Scroll**.
* A toggle for **Mute Autoplayed Videos**.
* **Visual Polish**: The mute setting features a premium micro-interaction: it smoothly transitions, fades out (`opacity: 0.5`), and disables mouse events when "Autoplay Videos on Scroll" is disabled.
* Added a clear hint warning the user that unmuting autoplaying videos may trigger browser autoplay restrictions.

### 3. Reusable Autoplay Hook
Created `src/hooks/useAutoplayVideo.ts` utilizing the standard Web `IntersectionObserver` API:
* Observes the bound `<video>` element on screen.
* Triggers `.play()` when the video is mostly on-screen (`intersectionRatio >= 0.5`).
* Triggers `.pause()` immediately when the video is partially or fully off-screen.
* Applies configured muted states before playing to comply with standard browser policies.
* Gracefully catch/ignores `AbortError` or `NotAllowedError` during browser autoplay negotiation.

### 4. Gallery Grid Integration
* Propagated settings via server page component -> client page component -> item component.
* Updated `src/app/gallery/components/GalleryItem.tsx` to bind `useAutoplayVideo` to the grid video.
* Conditionally guarded mouseover and focus play/pause triggers so they are safely bypassed when autoplay is active, preventing conflicting play/pause states.

### 5. Timeline Feed Integration
* Propagated settings through `src/app/timeline/page.tsx` and `src/app/timeline/page-client.tsx`.
* Refactored `PostCard.tsx` video rendering into a new co-located `PostVideo` component. This allows multiple video items within a single post card to independently bind the autoplay hook and play/pause seamlessly on scroll.
