### PR TITLE
feat(timeline,gallery): loading buffer for uninterrupted scrolling

### DIFF
--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -24,6 +24,7 @@ export default function GalleryPageClient({
   initialNextCursor,
   pageSize,
   scrollMode,
+  infiniteScrollBuffer,
   loopVideos,
   autoplayVideos,
   muteAutoplayVideos,
@@ -35,6 +36,7 @@ export default function GalleryPageClient({
   initialNextCursor: string | null;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  infiniteScrollBuffer: number;
   loopVideos: boolean;
   autoplayVideos: boolean;
   muteAutoplayVideos: boolean;
@@ -48,6 +50,7 @@ export default function GalleryPageClient({
       initialNextCursor={initialNextCursor}
       pageSize={pageSize}
       scrollMode={scrollMode}
+      infiniteScrollBuffer={infiniteScrollBuffer}
       loopVideos={loopVideos}
       autoplayVideos={autoplayVideos}
       muteAutoplayVideos={muteAutoplayVideos}
@@ -63,6 +66,7 @@ function GalleryPageContent({
   initialNextCursor,
   pageSize,
   scrollMode,
+  infiniteScrollBuffer,
   loopVideos,
   autoplayVideos,
   muteAutoplayVideos,
@@ -74,6 +78,7 @@ function GalleryPageContent({
   initialNextCursor: string | null;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  infiniteScrollBuffer: number;
   loopVideos: boolean;
   autoplayVideos: boolean;
   muteAutoplayVideos: boolean;
@@ -224,6 +229,7 @@ function GalleryPageContent({
           loadMore={loadMore}
           hasMore={hasMore}
           isLoading={isLoading}
+          rootMargin={`${infiniteScrollBuffer}px`}
         />
       )}
 

--- a/src/app/gallery/page.tsx
+++ b/src/app/gallery/page.tsx
@@ -43,6 +43,7 @@ export default async function GalleryPage({
       initialNextCursor={nextCursor}
       pageSize={limit}
       scrollMode={scrollMode}
+      infiniteScrollBuffer={settings.infiniteScrollBuffer ?? 300}
       loopVideos={settings.loopVideos}
       autoplayVideos={settings.autoplayVideos ?? false}
       muteAutoplayVideos={settings.muteAutoplayVideos ?? true}

--- a/src/app/settings/page-client.tsx
+++ b/src/app/settings/page-client.tsx
@@ -109,6 +109,18 @@ export default function SettingsPageClient({
     }
 
     if (
+      settings.app.infiniteScrollBuffer < 0 ||
+      settings.app.infiniteScrollBuffer > 2000
+    ) {
+      setNotification({
+        type: "error",
+        message: "Infinite scroll buffer must be between 0 and 2000 pixels.",
+      });
+      setIsSaving(false);
+      return;
+    }
+
+    if (
       settings.app.timelinePageSize < 1 ||
       settings.app.timelinePageSize > 500
     ) {
@@ -352,6 +364,34 @@ export default function SettingsPageClient({
                   />
                   <p className={styles.helperText}>
                     Number of posts rendered per page in timeline feed (1-500).
+                  </p>
+                </div>
+
+                <div className={styles.formGroup}>
+                  <label
+                    htmlFor="infiniteScrollBuffer"
+                    className={styles.label}
+                  >
+                    Infinite Scroll Buffer (px)
+                  </label>
+                  <input
+                    id="infiniteScrollBuffer"
+                    type="number"
+                    min="0"
+                    max="2000"
+                    value={settings.app.infiniteScrollBuffer}
+                    onChange={(e) =>
+                      handleAppChange(
+                        "infiniteScrollBuffer",
+                        parseInt(e.target.value, 10) || 300,
+                      )
+                    }
+                    className={styles.input}
+                    required
+                  />
+                  <p className={styles.helperText}>
+                    Distance in pixels off-screen to trigger loading next page
+                    (0-2000).
                   </p>
                 </div>
 

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -24,6 +24,7 @@ export default function TimelinePageClient({
   initialSort,
   pageSize,
   scrollMode,
+  infiniteScrollBuffer,
   loopVideos,
   autoplayVideos,
   muteAutoplayVideos,
@@ -36,6 +37,7 @@ export default function TimelinePageClient({
   initialSort: string;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  infiniteScrollBuffer: number;
   loopVideos: boolean;
   autoplayVideos: boolean;
   muteAutoplayVideos: boolean;
@@ -50,6 +52,7 @@ export default function TimelinePageClient({
       initialSort={initialSort}
       pageSize={pageSize}
       scrollMode={scrollMode}
+      infiniteScrollBuffer={infiniteScrollBuffer}
       loopVideos={loopVideos}
       autoplayVideos={autoplayVideos}
       muteAutoplayVideos={muteAutoplayVideos}
@@ -66,6 +69,7 @@ function TimelinePageContent({
   initialSort,
   pageSize,
   scrollMode,
+  infiniteScrollBuffer,
   loopVideos,
   autoplayVideos,
   muteAutoplayVideos,
@@ -78,6 +82,7 @@ function TimelinePageContent({
   initialSort: string;
   pageSize: number;
   scrollMode: "infinite" | "button";
+  infiniteScrollBuffer: number;
   loopVideos: boolean;
   autoplayVideos: boolean;
   muteAutoplayVideos: boolean;
@@ -257,6 +262,7 @@ function TimelinePageContent({
           loadMore={loadMore}
           hasMore={hasMore}
           isLoading={isLoading}
+          rootMargin={`${infiniteScrollBuffer}px`}
         />
       )}
 

--- a/src/app/timeline/page.tsx
+++ b/src/app/timeline/page.tsx
@@ -39,6 +39,7 @@ export default async function TimelinePage({
       initialSort={sortBy}
       pageSize={limit}
       scrollMode={scrollMode}
+      infiniteScrollBuffer={settings.infiniteScrollBuffer ?? 300}
       loopVideos={settings.loopVideos}
       autoplayVideos={autoplayVideos}
       muteAutoplayVideos={muteAutoplayVideos}

--- a/src/components/InfiniteScrollSentinel.tsx
+++ b/src/components/InfiniteScrollSentinel.tsx
@@ -7,14 +7,21 @@ interface InfiniteScrollSentinelProps {
   loadMore: () => void;
   hasMore: boolean;
   isLoading: boolean;
+  rootMargin?: string;
 }
 
 export default function InfiniteScrollSentinel({
   loadMore,
   hasMore,
   isLoading,
+  rootMargin,
 }: InfiniteScrollSentinelProps) {
-  const { sentinelRef } = useInfiniteScroll({ loadMore, hasMore, isLoading });
+  const { sentinelRef } = useInfiniteScroll({
+    loadMore,
+    hasMore,
+    isLoading,
+    rootMargin,
+  });
 
   return (
     <div ref={sentinelRef} className={styles.sentinel}>

--- a/src/hooks/useInfiniteScroll.ts
+++ b/src/hooks/useInfiniteScroll.ts
@@ -4,6 +4,7 @@ interface UseInfiniteScrollOptions {
   loadMore: () => void;
   hasMore: boolean;
   isLoading: boolean;
+  rootMargin?: string;
 }
 
 /**
@@ -16,6 +17,7 @@ export function useInfiniteScroll({
   loadMore,
   hasMore,
   isLoading,
+  rootMargin,
 }: UseInfiniteScrollOptions) {
   const observerRef = useRef<IntersectionObserver | null>(null);
 
@@ -36,12 +38,12 @@ export function useInfiniteScroll({
             loadMore();
           }
         },
-        { rootMargin: "200px" },
+        { rootMargin: rootMargin || "200px" },
       );
 
       observerRef.current.observe(node);
     },
-    [loadMore, hasMore, isLoading],
+    [loadMore, hasMore, isLoading, rootMargin],
   );
 
   // Cleanup on unmount

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -10,6 +10,7 @@ export interface AppSettings {
   condensePostLines: number;
   autoplayVideos: boolean;
   muteAutoplayVideos: boolean;
+  infiniteScrollBuffer: number;
 }
 
 export interface ScraperSettings {
@@ -48,6 +49,7 @@ export const DEFAULT_SETTINGS: SystemSettings = {
     condensePostLines: 2,
     autoplayVideos: false,
     muteAutoplayVideos: true,
+    infiniteScrollBuffer: 300,
   },
   scraper: {
     rateLimit: "5M",

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -111,6 +111,13 @@ test.describe
 
       expect(await destructiveOpsToggle.isChecked()).toBe(!initialChecked);
 
+      // Modify Infinite Scroll Buffer
+      const infiniteScrollBufferInput = page
+        .locator("#infiniteScrollBuffer")
+        .first();
+      await expect(infiniteScrollBufferInput).toBeAttached();
+      await infiniteScrollBufferInput.fill("450");
+
       // Save Changes
       const saveButton = page
         .getByRole("button", { name: "Save Changes" })
@@ -141,6 +148,9 @@ test.describe
           .first()
           .isChecked(),
       ).toBe(!initialChecked);
+      await expect(page.locator("#infiniteScrollBuffer").first()).toHaveValue(
+        "450",
+      );
     });
 
     test("can modify and save Scraper settings, and persists after reload", async ({
@@ -218,6 +228,30 @@ test.describe
       await expect(alert).toBeVisible({ timeout: 15000 });
       await expect(alert).toContainText(
         "Gallery page size must be between 1 and 500.",
+      );
+    });
+
+    test("validates App scroll buffer", async ({ page }) => {
+      const infiniteScrollBufferInput = page
+        .locator("#infiniteScrollBuffer")
+        .first();
+      await expect(infiniteScrollBufferInput).toBeAttached();
+
+      // Set invalid scroll buffer (below 0)
+      await infiniteScrollBufferInput.fill("-50");
+      await page.getByRole("button", { name: "Save Changes" }).first().click();
+      const alert = page.locator("[class*='notification']").first();
+      await expect(alert).toBeVisible({ timeout: 15000 });
+      await expect(alert).toContainText(
+        "Infinite scroll buffer must be between 0 and 2000 pixels.",
+      );
+
+      // Set invalid scroll buffer too large (above 2000)
+      await infiniteScrollBufferInput.fill("2050");
+      await page.getByRole("button", { name: "Save Changes" }).first().click();
+      await expect(alert).toBeVisible({ timeout: 15000 });
+      await expect(alert).toContainText(
+        "Infinite scroll buffer must be between 0 and 2000 pixels.",
       );
     });
 


### PR DESCRIPTION
### 1. Settings & Schema Layer
- **`src/types/settings.ts`**: Introduced `infiniteScrollBuffer: number` in `AppSettings` interface with a default value of `300` pixels in `DEFAULT_SETTINGS`.
- **`src/app/settings/page-client.tsx`**:
  - Added a responsive input group field with helpful description text for adjusting the "Infinite Scroll Buffer" in the settings layout.
  - Implemented boundary validation checks ensuring the setting must be a positive integer between `0` and `2000` pixels.

### 2. Infinite Scroll Components & Hook
- **`src/hooks/useInfiniteScroll.ts`**: Upgraded the intersection observer hook to accept an optional `rootMargin` parameter inside options, defaulting back to `"200px"` if unspecified.
- **`src/components/InfiniteScrollSentinel.tsx`**: Updated to support receiving a `rootMargin` string prop and forwarding it down to the hook.

### 3. Parent Feeds Integration
- **`src/app/gallery/page.tsx` & `src/app/timeline/page.tsx`**: Extracted `infiniteScrollBuffer` from system app settings on the server side and passed it down to client page components.
- **`src/app/gallery/page-client.tsx` & `src/app/timeline/page-client.tsx`**: Wired up page content managers to feed the dynamic root margin (`${infiniteScrollBuffer}px`) into `<InfiniteScrollSentinel />`.

### 4. Integration Verification
- **`tests/settings.spec.ts`**:
  - Expanded `can modify and save App settings` integration test to test loading, filling `"450"`, saving, and verifying that the scroll buffer value persists correctly upon reload.
  - Added `validates App scroll buffer` test case asserting that out-of-range scroll buffer values (such as `-50` and `2050`) trigger the correct validation error notification.
