### PR TITLE
feat(lightbox): allow loading more items while navigating with buffer

### DIFF
--- a/src/app/gallery/components/GalleryItem.tsx
+++ b/src/app/gallery/components/GalleryItem.tsx
@@ -13,6 +13,7 @@ interface GalleryItemProps {
   autoplayVideos: boolean;
   muteAutoplayVideos: boolean;
   onClick: () => void;
+  id?: string;
 }
 
 export default function GalleryItem({
@@ -22,6 +23,7 @@ export default function GalleryItem({
   autoplayVideos,
   muteAutoplayVideos,
   onClick,
+  id,
 }: GalleryItemProps) {
   const item = row.item;
   const count = row.groupCount || 1;
@@ -44,6 +46,7 @@ export default function GalleryItem({
   return (
     // biome-ignore lint/a11y/useSemanticElements: Maintains current styling structure
     <div
+      id={id}
       className={`${styles.item} ${isSelected ? styles.selectedItem : ""}`}
       onClick={onClick}
       onKeyDown={handleKeyActivate(onClick)}

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { deleteMediaItems } from "@/app/actions/gallery";
 import BulkActionBar from "@/app/gallery/components/BulkActionBar";
 import FilterBar from "@/app/gallery/components/FilterBar";
@@ -127,7 +127,23 @@ function GalleryPageContent({
     next: nextLightbox,
     prev: prevLightbox,
     setSelectedIndex,
-  } = useLightbox(items.length, (idx) => items[idx].groupItems.length);
+    isPageLoading,
+  } = useLightbox(items.length, (idx) => items[idx].groupItems.length, {
+    onLoadMore: loadMore,
+    hasMore,
+    isLoading,
+    preloadBuffer: 3,
+  });
+
+  // Keep background feed scroll in sync with lightbox active item
+  useEffect(() => {
+    if (selectedIndex !== null) {
+      const element = document.getElementById(`gallery-item-${selectedIndex}`);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      }
+    }
+  }, [selectedIndex]);
 
   async function handleBulkDelete(deleteFiles: boolean) {
     if (selectedCount === 0) return;
@@ -206,6 +222,7 @@ function GalleryPageContent({
           <GalleryItem
             key={row.item.id}
             row={row}
+            id={`gallery-item-${index}`}
             isSelected={row.groupItems.some((i) => selectedIds.has(i.item.id))}
             selectionMode={selectionMode}
             autoplayVideos={autoplayVideos}
@@ -287,6 +304,7 @@ function GalleryPageContent({
           onPrev={prevLightbox}
           onDelete={handleDeleteItem}
           loopVideos={loopVideos}
+          isPageLoading={isPageLoading}
         />
       )}
 

--- a/src/app/timeline/components/PostCard.tsx
+++ b/src/app/timeline/components/PostCard.tsx
@@ -22,6 +22,7 @@ interface PostCardProps {
   muteAutoplayVideos?: boolean;
   condensePostText?: boolean;
   condensePostLines?: number;
+  id?: string;
 }
 
 export default function PostCard({
@@ -33,6 +34,7 @@ export default function PostCard({
   muteAutoplayVideos = true,
   condensePostText = true,
   condensePostLines = 2,
+  id,
 }: PostCardProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [hasOverflow, setHasOverflow] = useState(false);
@@ -63,7 +65,7 @@ export default function PostCard({
   }, [condensePostText]);
 
   return (
-    <article className={styles.postCard}>
+    <article id={id} className={styles.postCard}>
       {/* Header: Avatar, Name, Date */}
       <div className={styles.postHeader}>
         {post.author?.avatar ? (

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import FilterBar from "@/app/timeline/components/FilterBar";
 import PostCard from "@/app/timeline/components/PostCard";
 import styles from "@/app/timeline/page.module.css";
@@ -115,7 +115,23 @@ function TimelinePageContent({
     close: closeLightbox,
     next: nextLightbox,
     prev: prevLightbox,
-  } = useLightbox(posts.length, (idx) => posts[idx].mediaItems.length);
+    isPageLoading,
+  } = useLightbox(posts.length, (idx) => posts[idx].mediaItems.length, {
+    onLoadMore: loadMore,
+    hasMore,
+    isLoading,
+    preloadBuffer: 3,
+  });
+
+  // Keep background feed scroll in sync with lightbox active item
+  useEffect(() => {
+    if (selectedIndex !== null) {
+      const element = document.getElementById(`timeline-post-${selectedIndex}`);
+      if (element) {
+        element.scrollIntoView({ behavior: "smooth", block: "nearest" });
+      }
+    }
+  }, [selectedIndex]);
 
   // Prepare Lightbox Data from current selection
   const lightboxProps = useMemo(() => {
@@ -245,6 +261,7 @@ function TimelinePageContent({
             key={post.id}
             post={post}
             postIndex={postIdx}
+            id={`timeline-post-${postIdx}`}
             onMediaClick={openLightbox}
             loopVideos={loopVideos}
             autoplayVideos={autoplayVideos}
@@ -287,6 +304,7 @@ function TimelinePageContent({
           onPrev={prevLightbox}
           onDelete={undefined}
           loopVideos={loopVideos}
+          isPageLoading={isPageLoading}
         />
       )}
     </div>

--- a/src/components/Lightbox.module.css
+++ b/src/components/Lightbox.module.css
@@ -486,3 +486,24 @@
   font-style: italic;
   margin-top: 4px;
 }
+
+.loadingButton {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid hsl(var(--foreground) / 0.2);
+  border-top-color: hsl(var(--foreground));
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -30,6 +30,7 @@ interface LightboxProps {
   onPrev?: () => void;
   onDelete?: (id: number, deleteFile: boolean) => void;
   loopVideos?: boolean;
+  isPageLoading?: boolean;
 }
 
 export default function Lightbox({
@@ -45,6 +46,7 @@ export default function Lightbox({
   onPrev,
   onDelete,
   loopVideos,
+  isPageLoading = false,
 }: LightboxProps) {
   const { item } = row;
   const [showInfo, setShowInfo] = useState(true);
@@ -119,7 +121,7 @@ export default function Lightbox({
       if (diffX > 0) {
         if (onPrev) onPrev();
       } else {
-        if (onNext) onNext();
+        if (onNext && !isPageLoading) onNext();
       }
     }
     touchStartX.current = null;
@@ -185,10 +187,10 @@ export default function Lightbox({
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       if (e.key === "Escape") onClose();
-      if (e.key === "ArrowRight" && onNext) onNext();
+      if (e.key === "ArrowRight" && onNext && !isPageLoading) onNext();
       if (e.key === "ArrowLeft" && onPrev) onPrev();
     },
-    [onClose, onNext, onPrev],
+    [onClose, onNext, onPrev, isPageLoading],
   );
 
   useEffect(() => {
@@ -305,13 +307,16 @@ export default function Lightbox({
         {onNext && (
           <button
             type="button"
-            className={`${styles.navButton} ${styles.nextButton}`}
+            className={`${styles.navButton} ${styles.nextButton} ${isPageLoading ? styles.loadingButton : ""}`}
             onClick={(e) => {
               e.stopPropagation();
+              if (isPageLoading) return;
               onNext();
             }}
+            disabled={isPageLoading}
+            title={isPageLoading ? "Loading next page..." : "Next"}
           >
-            ›
+            {isPageLoading ? <span className={styles.spinner} /> : "›"}
           </button>
         )}
 

--- a/src/hooks/useLightbox.ts
+++ b/src/hooks/useLightbox.ts
@@ -1,19 +1,80 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export function useLightbox(
   itemsLength: number,
   getGroupLength?: (index: number) => number,
+  options?: {
+    onLoadMore?: () => Promise<void> | void;
+    hasMore?: boolean;
+    isLoading?: boolean;
+    preloadBuffer?: number;
+  },
 ) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [mediaIndex, setMediaIndex] = useState(0);
+  const [prevItemsLength, setPrevItemsLength] = useState(itemsLength);
+  const [shouldAdvancePending, setShouldAdvancePending] = useState(false);
+  const [prevIsLoading, setPrevIsLoading] = useState(false);
+
+  const preloadBuffer = options?.preloadBuffer ?? 3;
+
+  // Sync external itemsLength updates when not waiting to advance
+  if (itemsLength !== prevItemsLength && !shouldAdvancePending) {
+    setPrevItemsLength(itemsLength);
+  }
+
+  // Proactively fetch more items in the background when getting close to the end of the loaded feed
+  useEffect(() => {
+    if (
+      selectedIndex !== null &&
+      options?.hasMore &&
+      options?.onLoadMore &&
+      !options.isLoading &&
+      !shouldAdvancePending &&
+      itemsLength - 1 - selectedIndex <= preloadBuffer
+    ) {
+      options.onLoadMore();
+    }
+  }, [
+    selectedIndex,
+    itemsLength,
+    preloadBuffer,
+    options?.hasMore,
+    options?.onLoadMore,
+    options?.isLoading,
+    shouldAdvancePending,
+  ]);
+
+  // If itemsLength increases while we are pending, immediately advance to the first new item
+  if (shouldAdvancePending && itemsLength > prevItemsLength) {
+    setSelectedIndex(prevItemsLength);
+    setMediaIndex(0);
+    setPrevItemsLength(itemsLength);
+    setShouldAdvancePending(false);
+  }
+
+  // Handle loading completion when we are pending (cancel pending if no items were added)
+  useEffect(() => {
+    if (options?.isLoading !== undefined) {
+      if (prevIsLoading && !options.isLoading) {
+        if (shouldAdvancePending) {
+          // Finished loading but length didn't change (no more records available)
+          setShouldAdvancePending(false);
+        }
+      }
+      setPrevIsLoading(options.isLoading);
+    }
+  }, [options?.isLoading, prevIsLoading, shouldAdvancePending]);
 
   const open = (index: number, mIndex: number = 0) => {
     setSelectedIndex(index);
     setMediaIndex(mIndex);
+    setShouldAdvancePending(false);
   };
 
   const close = () => {
     setSelectedIndex(null);
+    setShouldAdvancePending(false);
   };
 
   const next = () => {
@@ -26,11 +87,20 @@ export function useLightbox(
     } else if (selectedIndex < itemsLength - 1) {
       setSelectedIndex(selectedIndex + 1);
       setMediaIndex(0);
+    } else if (
+      options?.hasMore &&
+      options?.onLoadMore &&
+      !options.isLoading &&
+      !shouldAdvancePending
+    ) {
+      setShouldAdvancePending(true);
+      options.onLoadMore();
     }
   };
 
   const prev = () => {
     if (selectedIndex === null) return;
+    setShouldAdvancePending(false); // Reset pending load-more advance if user decides to browse backward
 
     if (mediaIndex > 0) {
       setMediaIndex(mediaIndex - 1);
@@ -46,6 +116,7 @@ export function useLightbox(
     selectedIndex,
     mediaIndex,
     isOpen: selectedIndex !== null,
+    isPageLoading: shouldAdvancePending,
     open,
     close,
     next,


### PR DESCRIPTION
## 1. Summary of Changes

### 1.1 Hook Updates
- **[useLightbox.ts](src/hooks/useLightbox.ts)**:
  - Extended the hook to accept options: `onLoadMore`, `hasMore`, `isLoading`, and `preloadBuffer` (default: 3).
  - Added background prefetching that triggers `onLoadMore()` in the background when the user gets within the `preloadBuffer` range of the loaded items count.
  - Implemented a smart page loader transition flag (`isPageLoading`) that is returned to show a spinner on the Next button when loading.
  - Automatically advances `selectedIndex` to `prevItemsLength` (the first new item) and resets `shouldAdvancePending` to `false` when list length increases.
  - Gracefully cancels pending advance states if the user decides to browse backward (`prev`) or close (`close`) the lightbox during a load.

### 1.2 Component and Styling Updates
- **[Lightbox.tsx](src/components/Lightbox.tsx)**:
  - Added `isPageLoading` to props and used it to style/debounce the Next button.
  - Rendered a premium rotating CSS spinner inside the Next button instead of standard "›" while loading, and disabled clicks.
  - Left backward navigation (`prev` / ArrowLeft / swipe right) and close operations (`close` / Escape) active at all times.
- **[Lightbox.module.css](src/components/Lightbox.module.css)**:
  - Added the `.loadingButton` and `.spinner` CSS module classes.
  - Added CSS spin animation keyframes.

### 1.3 Page Integration & Scroll-Syncing
- **[GalleryPage](src/app/gallery/page-client.tsx)** & **[GalleryItem](src/app/gallery/components/GalleryItem.tsx)**:
  - Connected `useLightbox` with state options from `usePaginatedData`.
  - Added a unique DOM `id={`gallery-item-${index}`}` to the root of `GalleryItem`.
  - Implemented a `useEffect` that programmatically scrolls the active gallery item into view smoothly in the background as navigation progresses.
- **[TimelinePage](src/app/timeline/page-client.tsx)** & **[PostCard](src/app/timeline/components/PostCard.tsx)**:
  - Connected `useLightbox` with state options from `usePaginatedData`.
  - Added a unique DOM `id={`timeline-post-${postIdx}`}` to the root of `PostCard`.
  - Implemented a `useEffect` that programmatically scrolls the active post card into view smoothly in the background as navigation progresses.
