### PR TITLE
89 scans triggered by scrapes should only scan new posts

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -243,23 +243,31 @@ ScraperManager (singleton)
 
 **Location**: [`src/lib/library/`](./src/lib/library/)
 
-The scanner (`syncLibrary()`) walks the `downloads/` directory, groups files by parent directory, matches media files to their co-located JSON metadata files, and upserts everything into the database.
+The scanner uses a module-level FIFO scan queue (`queueScan()`) to serialize all library scans sequentially rather than dropping concurrent scan requests. It supports two modes: **Full Scan** (walks the entire download directory, index everything, and purge deleted items) and **Incremental Scan** (precision walks only the directories containing new/updated files, processes only the targeted files, and skips deletion checks entirely for high-speed scrape integration).
 
 ```
-syncLibrary()
-  ├── Walk DOWNLOAD_DIR → dirGroups (media + JSON per directory)
-  ├── Load in-memory caches (existing media paths, users, posts, tags)
-  ├── Match media files → JSON files (exact, prefix, or contains)
-  ├── Build ProcessTask list
-  └── Batched DB transactions (BATCH_SIZE = 100)
-        └── For each task:
-              ├── prepareTask() — read JSON + stat the file
-              ├── MetadataProcessorFactory.getProcessor(extractorType)
-              │     └── processor.process(meta, task, context)
-              │           ├── Upsert platform user (twitterUsers / pixivUsers)
-              │           ├── Upsert post + platform detail table
-              │           └── Upsert tags → postTags
-              └── Insert/update mediaItems row
+queueScan() / queueIncrementalScan()
+  └── FIFO Queue
+        └── syncLibrary(options)
+              ├── File Discovery:
+              │     ├── Full: Walk DOWNLOAD_DIR recursively
+              │     └── Incremental: Walk only parent dirs of targetFiles
+              ├── Group files by dir → dirGroups (media + JSON per directory)
+              ├── Load in-memory caches (existing media paths, users, posts, tags)
+              ├── Match media files ↔ JSON files (exact, prefix, or contains)
+              ├── Build ProcessTask list:
+              │     ├── Full: Process all matched tasks
+              │     └── Incremental: Filter to tasks where media or JSON is in targetFiles
+              ├── Batched DB transactions (BATCH_SIZE = 100)
+              │     └── For each task:
+              │           ├── prepareTask() — read JSON + stat the file
+              │           ├── MetadataProcessorFactory.getProcessor(extractorType)
+              │           │     └── processor.process(meta, task, context)
+              │           │           ├── Upsert platform user
+              │           │           ├── Upsert post + details
+              │           │           └── Upsert tags
+              │           └── Insert/update mediaItems row
+              └── Deletion cleanup (Full scan only)
 ```
 
 **Processors** follow the Strategy + Factory pattern:
@@ -342,13 +350,20 @@ ScraperManager.startScrape(sourceId, type, url, downloadDir)
 ScraperManager finalizes scrape_history
         │
         ▼
-syncLibrary() triggered automatically
+queueIncrementalScan(result.items)
         │
-        ├── Walks DOWNLOAD_DIR
-        ├── Matches media ↔ JSON
+        ▼
+Scan Queue (FIFO serialization)
+        │
+        ▼
+syncLibrary({ targetFiles, scanType: "incremental" })
+        │
+        ├── Walks only parent directories of targetFiles
+        ├── Matches media ↔ JSON within those directories
+        ├── Filters ProcessTask list to only new/updated files
         ├── MetadataProcessorFactory → processor.process()
         │       └── Upserts: users, posts, post_details_*, tags, mediaItems
-        └── Finalizes scan_history (status: "completed")
+        └── Finalizes scan_history (status: "completed", type: "incremental")
                 │
                 ▼
         Gallery / Timeline pages now show new content

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ Client pages consume this with a "Load More" button that calls the Route Handler
 - **Scraping**: `ScraperManager` singleton controls scraping tasks. Strategies implement `BaseScraperStrategy` → `GalleryDlStrategy`, `YtDlpStrategy`.
 - **Library Scanning**: `MetadataProcessorFactory` handles metadata extraction per platform (Twitter, Pixiv, Gelbooru).
 - **Rule**: When adding support for a new platform, implement a new strategy/processor. Never add `if/else` platform logic to base classes.
+- **Rule**: Post-scrape scans must be incremental (file-level targeted via `queueIncrementalScan`) and go through the scan queue. The manual "Scan Library" button triggers a full scan via `queueScan({ scanType: "full" })`. Never call `syncLibrary()` directly — always use the queue functions to ensure serialization.
 - **Rule**: If a new extractor introduces new searchable metadata columns that are added to the FTS5 virtual table, you MUST update the `ftsColumnAliases` dictionary in `src/lib/utils/search-parser.ts` to map any friendly search prefixes to the new FTS5 column. This dictionary doubles as the allowlist for valid column filters.
 
 ### 1.5 Styling System — CSS Modules + Design Tokens

--- a/drizzle/0007_powerful_bug.sql
+++ b/drizzle/0007_powerful_bug.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `scan_history` ADD `scan_type` text DEFAULT 'full';

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,1414 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "dfc21c3b-379e-40b0-b284-38df904f9af2",
+  "prevId": "2c4b2dc6-ca4f-47e3-ac8f-0bc13d697d40",
+  "tables": {
+    "gallerydl_extractor_types": {
+      "name": "gallerydl_extractor_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_post_id_posts_id_fk": {
+          "name": "media_items_post_id_posts_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pixiv_users": {
+      "name": "pixiv_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_followed": {
+          "name": "is_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_accept_request": {
+          "name": "is_accept_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlist_items": {
+      "name": "playlist_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playlist_items_playlist_id_playlists_id_fk": {
+          "name": "playlist_items_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_items_media_item_id_media_items_id_fk": {
+          "name": "playlist_items_media_item_id_media_items_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "media_items",
+          "columnsFrom": ["media_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_gelbooruv02": {
+      "name": "post_details_gelbooruv02",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "md5": {
+          "name": "md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_gelbooruv02_post_id_posts_id_fk": {
+          "name": "post_details_gelbooruv02_post_id_posts_id_fk",
+          "tableFrom": "post_details_gelbooruv02",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_pixiv": {
+      "name": "post_details_pixiv",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restrict": {
+          "name": "restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x_restrict": {
+          "name": "x_restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sanity_level": {
+          "name": "sanity_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_view": {
+          "name": "total_view",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_bookmarks": {
+          "name": "total_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_bookmarked": {
+          "name": "is_bookmarked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_ai_type": {
+          "name": "illust_ai_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_book_style": {
+          "name": "illust_book_style",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_pixiv_post_id_posts_id_fk": {
+          "name": "post_details_pixiv_post_id_posts_id_fk",
+          "tableFrom": "post_details_pixiv",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_twitter": {
+      "name": "post_details_twitter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retweet_id": {
+          "name": "retweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_id": {
+          "name": "reply_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive_flags": {
+          "name": "sensitive_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite_count": {
+          "name": "favorite_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_count": {
+          "name": "quote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retweet_count": {
+          "name": "retweet_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bookmark_count": {
+          "name": "bookmark_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_twitter_post_id_posts_id_fk": {
+          "name": "post_details_twitter_post_id_posts_id_fk",
+          "tableFrom": "post_details_twitter",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_tag_id_post_id_pk": {
+          "columns": ["tag_id", "post_id"],
+          "name": "post_tags_tag_id_post_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_source_id": {
+          "name": "json_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_source_id": {
+          "name": "internal_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_path": {
+          "name": "metadata_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_internal_source_id_sources_id_fk": {
+          "name": "posts_internal_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["internal_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_history": {
+      "name": "scan_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_type": {
+          "name": "scan_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "files_processed": {
+          "name": "files_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_added": {
+          "name": "files_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_updated": {
+          "name": "files_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_deleted": {
+          "name": "files_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scrape_history": {
+      "name": "scrape_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_downloaded": {
+          "name": "files_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_processed": {
+          "name": "posts_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_speed": {
+          "name": "average_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scrape_history_source_id_sources_id_fk": {
+          "name": "scrape_history_source_id_sources_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_history_task_id_scraping_tasks_id_fk": {
+          "name": "scrape_history_task_id_scraping_tasks_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "scraping_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraper_download_logs": {
+      "name": "scraper_download_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scraper_download_logs_file_path_unique": {
+          "name": "scraper_download_logs_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "scraper_download_logs_source_id_sources_id_fk": {
+          "name": "scraper_download_logs_source_id_sources_id_fk",
+          "tableFrom": "scraper_download_logs",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraping_tasks": {
+      "name": "scraping_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_options": {
+          "name": "download_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scraping_tasks_source_id_sources_id_fk": {
+          "name": "scraping_tasks_source_id_sources_id_fk",
+          "tableFrom": "scraping_tasks",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sources_extractor_type_gallerydl_extractor_types_id_fk": {
+          "name": "sources_extractor_type_gallerydl_extractor_types_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "gallerydl_extractor_types",
+          "columnsFrom": ["extractor_type"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twitter_users": {
+      "name": "twitter_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nick": {
+          "name": "nick",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_banner": {
+          "name": "profile_banner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favourites_count": {
+          "name": "favourites_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "friends_count": {
+          "name": "friends_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listed_count": {
+          "name": "listed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_count": {
+          "name": "media_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "statuses_count": {
+          "name": "statuses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1779834387840,
       "tag": "0006_add_media_dimensions",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1779845076998,
+      "tag": "0007_powerful_bug",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/scanning.ts
+++ b/src/app/actions/scanning.ts
@@ -3,10 +3,10 @@
 import { desc } from "drizzle-orm";
 import { db } from "@/lib/db";
 import { scanHistory } from "@/lib/db/schema";
-import { stopScanning, syncLibrary } from "@/lib/library/scanner";
+import { queueScan, stopScanning } from "@/lib/library/scanner";
 
 export async function scanLibrary() {
-  syncLibrary().catch(console.error);
+  queueScan({ scanType: "full" });
   return { started: true };
 }
 

--- a/src/app/api/library/scan/route.ts
+++ b/src/app/api/library/scan/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 import { db } from "@/lib/db";
 import { scanHistory } from "@/lib/db/schema";
 
-import { syncLibrary } from "@/lib/library/scanner";
+import { queueScan } from "@/lib/library/scanner";
 
 export async function GET() {
   // Return the latest scan record as-is.
@@ -19,6 +19,6 @@ export async function GET() {
 }
 
 export async function POST() {
-  syncLibrary().catch(console.error);
+  queueScan({ scanType: "full" });
   return NextResponse.json({ started: true });
 }

--- a/src/app/library/page-client.tsx
+++ b/src/app/library/page-client.tsx
@@ -136,6 +136,11 @@ export default function LibraryPageClient({
                 >
                   {scanStatus.status}
                 </span>
+                {scanStatus.scanType && (
+                  <span className={styles.scanTypeBadge}>
+                    {scanStatus.scanType}
+                  </span>
+                )}
               </div>
               {scanStatus.status === "running" && (
                 <div>

--- a/src/app/library/page.module.css
+++ b/src/app/library/page.module.css
@@ -127,6 +127,17 @@
   color: hsl(var(--color-info) / 0.8);
 }
 
+.scanTypeBadge {
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  background: hsl(var(--color-muted-label) / 0.1);
+  color: hsl(var(--color-muted-label));
+  margin-left: 0.5rem;
+  text-transform: capitalize;
+}
+
 /* Danger Zone */
 .dangerZone {
   border-color: rgba(239, 68, 68, 0.2);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -89,6 +89,7 @@ export const scanHistory = sqliteTable("scan_history", {
   status: text("status")
     .$type<"running" | "completed" | "failed" | "stopped">()
     .notNull(),
+  scanType: text("scan_type").$type<"full" | "incremental">().default("full"),
   filesProcessed: integer("files_processed").default(0),
   filesAdded: integer("files_added").default(0),
   filesUpdated: integer("files_updated").default(0),

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -18,6 +18,7 @@ import { MetadataProcessorFactory } from "@/lib/library/processors/factory";
 import type {
   ProcessorContext,
   ProcessTask,
+  SyncOptions,
   TagCache,
   UserCache,
 } from "@/lib/library/types";
@@ -27,6 +28,40 @@ const DOWNLOAD_DIR = paths.downloads;
 // Global control flags for this module process
 let isScanning = false;
 let stopRequested = false;
+
+const scanQueue: SyncOptions[] = [];
+let isProcessingQueue = false;
+
+export function queueScan(options: SyncOptions = { scanType: "full" }): void {
+  scanQueue.push(options);
+  if (!isProcessingQueue) {
+    processQueue().catch((err) =>
+      console.error("[Scanner] Queue processing error:", err),
+    );
+  }
+}
+
+async function processQueue(): Promise<void> {
+  if (isProcessingQueue) return;
+  isProcessingQueue = true;
+  try {
+    while (scanQueue.length > 0) {
+      const next = scanQueue.shift()!;
+      await syncLibrary(next);
+    }
+  } finally {
+    isProcessingQueue = false;
+  }
+}
+
+export function queueIncrementalScan(downloadedFiles: string[]): void {
+  if (downloadedFiles.length === 0) return;
+
+  queueScan({
+    targetFiles: downloadedFiles,
+    scanType: "incremental",
+  });
+}
 
 export function isScanRunning(): boolean {
   return isScanning;
@@ -107,13 +142,14 @@ function getAllFiles(dirPath: string): string[] {
   return results;
 }
 
-export async function syncLibrary() {
+export async function syncLibrary(options?: SyncOptions) {
   if (isScanning) {
     console.warn("Scan already running.");
     return;
   }
 
-  console.log("Starting library sync...");
+  const scanType = options?.scanType || "full";
+  console.log(`Starting library sync (${scanType})...`);
   isScanning = true;
   stopRequested = false;
 
@@ -125,6 +161,7 @@ export async function syncLibrary() {
     .values({
       startTime: new Date(),
       status: "running",
+      scanType,
       filesProcessed: 0,
       filesAdded: 0,
       filesUpdated: 0,
@@ -146,7 +183,21 @@ export async function syncLibrary() {
     // Enable WAL mode for much better write throughput during bulk operations
     await db.run(sql`PRAGMA journal_mode=WAL`);
 
-    const legacyFiles = getAllFiles(DOWNLOAD_DIR);
+    let legacyFiles: string[] = [];
+    if (scanType === "incremental" && options?.targetFiles) {
+      const parentDirs = new Set<string>();
+      for (const file of options.targetFiles) {
+        parentDirs.add(path.dirname(path.resolve(file)));
+      }
+      for (const dir of parentDirs) {
+        if (fs.existsSync(dir)) {
+          legacyFiles = legacyFiles.concat(getAllFiles(dir));
+        }
+      }
+      legacyFiles = Array.from(new Set(legacyFiles));
+    } else {
+      legacyFiles = getAllFiles(DOWNLOAD_DIR);
+    }
 
     console.log(`Found ${legacyFiles.length} files in downloads.`);
 
@@ -269,6 +320,12 @@ export async function syncLibrary() {
       ])
       .onConflictDoNothing();
 
+    const isIncremental = scanType === "incremental" && options?.targetFiles;
+    const targetSet =
+      isIncremental && options?.targetFiles
+        ? new Set(options.targetFiles.map((f) => path.resolve(f)))
+        : null;
+
     const processedPaths = new Set<string>();
     const tasks: ProcessTask[] = [];
 
@@ -315,56 +372,74 @@ export async function syncLibrary() {
       }
 
       for (const mediaPath of group.mediaFiles) {
-        let urlPath: string;
-        if (group.sourceId) {
-          const relativePath = path
-            .relative(group.sourceRoot, mediaPath)
-            .split(path.sep)
-            .join("/");
-          urlPath = `/api/media/${group.sourceId}/${relativePath}`;
-        } else {
-          const relativePath = path
-            .relative(group.sourceRoot, mediaPath)
-            .split(path.sep)
-            .join("/");
-          urlPath = `/${relativePath}`;
-        }
+        const fsPathResolved = path.resolve(mediaPath);
+        const matchedJson = mediaToJson.get(mediaPath);
+        const matchedJsonResolved = matchedJson
+          ? path.resolve(matchedJson)
+          : undefined;
 
-        processedPaths.add(urlPath);
-        tasks.push({
-          fsPath: mediaPath,
-          dbFilePath: urlPath,
-          jsonPath: mediaToJson.get(mediaPath),
-          defaultType: "image",
-          sourceId: group.sourceId,
-        });
-      }
+        const isTargeted =
+          !targetSet ||
+          targetSet.has(fsPathResolved) ||
+          (matchedJsonResolved && targetSet.has(matchedJsonResolved));
 
-      // Process unused JSONs (Text-only posts)
-      for (const jsonPath of group.jsonFiles) {
-        if (!usedJsons.has(jsonPath)) {
+        if (isTargeted) {
           let urlPath: string;
           if (group.sourceId) {
             const relativePath = path
-              .relative(group.sourceRoot, jsonPath)
+              .relative(group.sourceRoot, mediaPath)
               .split(path.sep)
               .join("/");
             urlPath = `/api/media/${group.sourceId}/${relativePath}`;
           } else {
             const relativePath = path
-              .relative(group.sourceRoot, jsonPath)
+              .relative(group.sourceRoot, mediaPath)
               .split(path.sep)
               .join("/");
             urlPath = `/${relativePath}`;
           }
 
+          processedPaths.add(urlPath);
           tasks.push({
-            fsPath: jsonPath,
+            fsPath: mediaPath,
             dbFilePath: urlPath,
-            jsonPath: jsonPath,
-            defaultType: "text",
+            jsonPath: matchedJson,
+            defaultType: "image",
             sourceId: group.sourceId,
           });
+        }
+      }
+
+      // Process unused JSONs (Text-only posts)
+      for (const jsonPath of group.jsonFiles) {
+        if (!usedJsons.has(jsonPath)) {
+          const jsonPathResolved = path.resolve(jsonPath);
+          const isTargeted = !targetSet || targetSet.has(jsonPathResolved);
+
+          if (isTargeted) {
+            let urlPath: string;
+            if (group.sourceId) {
+              const relativePath = path
+                .relative(group.sourceRoot, jsonPath)
+                .split(path.sep)
+                .join("/");
+              urlPath = `/api/media/${group.sourceId}/${relativePath}`;
+            } else {
+              const relativePath = path
+                .relative(group.sourceRoot, jsonPath)
+                .split(path.sep)
+                .join("/");
+              urlPath = `/${relativePath}`;
+            }
+
+            tasks.push({
+              fsPath: jsonPath,
+              dbFilePath: urlPath,
+              jsonPath: jsonPath,
+              defaultType: "text",
+              sourceId: group.sourceId,
+            });
+          }
         }
       }
     }
@@ -460,7 +535,7 @@ export async function syncLibrary() {
       }
     }
 
-    if (!stopRequested) {
+    if (scanType === "full" && !stopRequested) {
       console.log("Cleaning up removed items...");
       const pathsToDelete: string[] = [];
       for (const p of existingMediaPaths) {

--- a/src/lib/library/types.ts
+++ b/src/lib/library/types.ts
@@ -20,3 +20,10 @@ export interface ProcessorContext {
   userAvatars: Map<string, string>;
   internalSourceId: number | null;
 }
+
+export interface SyncOptions {
+  /** Specific files to target (incremental mode). Parent dirs are walked for JSON matching context only. */
+  targetFiles?: string[];
+  /** 'full' = walk all + cleanup deletions. 'incremental' = process only targetFiles, skip deletion. */
+  scanType?: "full" | "incremental";
+}

--- a/src/lib/scrapers/manager.ts
+++ b/src/lib/scrapers/manager.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { paths } from "@/lib/config";
 import { db } from "@/lib/db";
 import { scrapeHistory, scraperDownloadLogs } from "@/lib/db/schema";
-import { syncLibrary } from "@/lib/library/scanner";
+import { queueIncrementalScan } from "@/lib/library/scanner";
 import { type ScrapeLimits, ScraperRunner } from "@/lib/scrapers/runner";
 import type { BaseScraperStrategy } from "@/lib/scrapers/strategies/base";
 import type { ScrapeProgress } from "@/lib/scrapers/types";
@@ -296,11 +296,11 @@ class ScraperManager {
             `[ScraperManager] Updated history record ${historyId} with final metrics`,
           );
 
-          // Trigger library scan automatically
-          console.log(`[ScraperManager] Triggering library scan...`);
-          syncLibrary().catch((err) =>
-            console.error("[ScraperManager] Auto-scan failed:", err),
+          // Queue incremental scan for only the downloaded files
+          console.log(
+            `[ScraperManager] Queuing incremental scan for ${result.items?.length ?? 0} downloaded files...`,
           );
+          queueIncrementalScan(result.items ?? []);
 
           // Keep it in the map for a bit so the UI can see "Finished"
           setTimeout(() => {
@@ -323,12 +323,9 @@ class ScraperManager {
 
         this.activeScrapes.delete(sourceId);
 
-        // Should we scan on error? Probably yes, to pick up whatever was downloaded before error.
+        // No result.items available on promise rejection — log and let user manually full-scan if needed
         console.log(
-          `[ScraperManager] Triggering library scan (after error)...`,
-        );
-        syncLibrary().catch((err) =>
-          console.error("[ScraperManager] Auto-scan failed:", err),
+          `[ScraperManager] Scrape failed for source ${sourceId}. No incremental scan queued — use manual full scan if needed.`,
         );
       });
   }


### PR DESCRIPTION
Successfully implemented incremental scanning for post-scrape library updates. When a scrape finishes, it now only indexes the newly downloaded files rather than executing a full recursive scan of the entire download directory. In addition, concurrent scan requests are sequentialized using a module-level FIFO queue to prevent dropped updates.

## Changes Made

### 1. `feat(db): add scanType column to scan_history`
- Modified [schema.ts](src/lib/db/schema.ts) to add a `scanType` column (`"full" | "incremental"`) to the `scan_history` table (nullable, defaulting to `"full"`).
- Generated Drizzle Kit migration `drizzle/0007_powerful_bug.sql` successfully.

### 2. `feat(scanner): add scan queue and incremental scan mode`
- Added the `SyncOptions` interface in [types.ts](src/lib/library/types.ts).
- Added a module-level FIFO scan queue (`scanQueue[]`, `isProcessingQueue`, `queueScan()`, and `processQueue()`) in [scanner.ts](src/lib/library/scanner.ts) to serialize scans.
- Parameterized `syncLibrary(options?: SyncOptions)` to support target-file filtering and incremental logic.
- Implemented file-level incremental targeting:
  1. Derives unique parent directories from `targetFiles` to precision-walk them and preserve JSON↔media matching context.
  2. Filters `tasks` so only media files or metadata JSONs matching `targetFiles` are processed.
  3. Skips the database deletion/cleanup pass entirely in incremental scans.
- Added `queueIncrementalScan(downloadedFiles)` helper method.

### 3. `feat(scraper): trigger incremental scan after scrape completion`
- Modified [manager.ts](src/lib/scrapers/manager.ts) to trigger the high-speed incremental scan via `queueIncrementalScan(result.items)` on success.
- Skip scanning entirely on scrape error to avoid redundant scan noise.
- Updated the manual scan server action in [scanning.ts](src/app/actions/scanning.ts) and scan API route in [route.ts](src/app/api/library/scan/route.ts) to use `queueScan({ scanType: "full" })` so manual triggers remain full.

### 4. `feat(library): display scan type in library page UI`
- Modified [page-client.tsx](src/app/library/page-client.tsx) to render a dynamic badge with the scan type (`full` or `incremental`) next to the status.
- Added premium capsule styling for `.scanTypeBadge` in [page.module.css](src/app/library/page.module.css) using HSL design tokens (`--color-muted-label`).

### 5. `docs: document incremental scanning and scan queue`
- Updated the Library Scanner architectural docs in [ARCHITECTURE.md](ARCHITECTURE.md) (§3.4 & §4.1) outlining the queue execution and incremental scan design.
- Added rule instructions in [CONTRIBUTING.md](CONTRIBUTING.md) (§1.4) explaining the serialization requirement and deprecating direct `syncLibrary()` calls.

