### PR TITLE
(#98) fix date sorting in gallery

### DIFF
--- a/src/app/gallery/components/FilterBar.tsx
+++ b/src/app/gallery/components/FilterBar.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { CheckSquare, Minus, Plus, Square } from "lucide-react";
+import {
+  ArrowDown,
+  ArrowUp,
+  CheckSquare,
+  Minus,
+  Plus,
+  Square,
+} from "lucide-react";
 import styles from "@/app/gallery/page.module.css";
 
 interface FilterBarProps {
@@ -28,6 +35,29 @@ export default function FilterBar({
   setColumnCount,
   onRefresh,
 }: FilterBarProps) {
+  // Parse field and direction from sortBy state
+  const isRelevance = sortBy === "relevance";
+  const currentField = isRelevance ? "relevance" : sortBy.split("-")[0];
+  const currentDir = isRelevance
+    ? "desc"
+    : sortBy.endsWith("-asc")
+      ? "asc"
+      : "desc";
+
+  const handleFieldChange = (newField: string) => {
+    if (newField === "relevance") {
+      setSortBy("relevance");
+    } else {
+      setSortBy(`${newField}-${currentDir}`);
+    }
+  };
+
+  const handleDirToggle = () => {
+    if (isRelevance) return;
+    const nextDir = currentDir === "desc" ? "asc" : "desc";
+    setSortBy(`${currentField}-${nextDir}`);
+  };
+
   return (
     <div className={styles.filterBar}>
       <button
@@ -61,18 +91,36 @@ export default function FilterBar({
         className={`${styles.input} ${styles.searchInput}`}
       />
       <select
-        value={sortBy}
-        onChange={(e) => setSortBy(e.target.value)}
+        value={currentField}
+        onChange={(e) => handleFieldChange(e.target.value)}
         className={styles.input}
       >
-        <option value="created-desc">Imported: Newest First</option>
-        <option value="created-asc">Oldest First</option>
-        <option value="captured-desc">Content Date: Newest First</option>
-        <option value="captured-asc">Content Date: Oldest First</option>
+        <option value="created">Imported to Library</option>
+        <option value="captured">Original Post Date</option>
         <option value="relevance" disabled={searchQuery.trim().length === 0}>
           Relevance (Search Only)
         </option>
       </select>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={handleDirToggle}
+        disabled={isRelevance}
+        title={
+          isRelevance
+            ? "Sorting by relevance does not support direction"
+            : currentDir === "desc"
+              ? "Sort Ascending (Oldest First)"
+              : "Sort Descending (Newest First)"
+        }
+        aria-label="Toggle sort direction"
+      >
+        {currentDir === "desc" ? (
+          <ArrowDown size={18} />
+        ) : (
+          <ArrowUp size={18} />
+        )}
+      </button>
       <div className={styles.separator} />
       <div className={styles.columnControl}>
         <span className={styles.label}>Columns: {columnCount}</span>

--- a/src/app/timeline/components/FilterBar.tsx
+++ b/src/app/timeline/components/FilterBar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ArrowDown, ArrowUp } from "lucide-react";
 import styles from "@/app/timeline/page.module.css";
 
 interface FilterBarProps {
@@ -15,6 +16,29 @@ export default function FilterBar({
   sortBy,
   setSortBy,
 }: FilterBarProps) {
+  // Parse field and direction from sortBy state
+  const isRelevance = sortBy === "relevance";
+  const currentField = isRelevance ? "relevance" : sortBy.split("-")[0];
+  const currentDir = isRelevance
+    ? "desc"
+    : sortBy.endsWith("-asc")
+      ? "asc"
+      : "desc";
+
+  const handleFieldChange = (newField: string) => {
+    if (newField === "relevance") {
+      setSortBy("relevance");
+    } else {
+      setSortBy(`${newField}-${currentDir}`);
+    }
+  };
+
+  const handleDirToggle = () => {
+    if (isRelevance) return;
+    const nextDir = currentDir === "desc" ? "asc" : "desc";
+    setSortBy(`${currentField}-${nextDir}`);
+  };
+
   return (
     <div className={styles.filterBar}>
       <input
@@ -26,18 +50,36 @@ export default function FilterBar({
       />
       <div className={styles.separator} />
       <select
-        value={sortBy}
-        onChange={(e) => setSortBy(e.target.value)}
+        value={currentField}
+        onChange={(e) => handleFieldChange(e.target.value)}
         className={styles.input}
       >
-        <option value="created-desc">Imported: Newest First</option>
-        <option value="created-asc">Oldest First</option>
-        <option value="captured-desc">Content Date: Newest First</option>
-        <option value="captured-asc">Content Date: Oldest First</option>
+        <option value="created">Imported to Library</option>
+        <option value="captured">Original Post Date</option>
         <option value="relevance" disabled={searchQuery.trim().length === 0}>
           Relevance (Search Only)
         </option>
       </select>
+      <button
+        type="button"
+        className={styles.iconButton}
+        onClick={handleDirToggle}
+        disabled={isRelevance}
+        title={
+          isRelevance
+            ? "Sorting by relevance does not support direction"
+            : currentDir === "desc"
+              ? "Sort Ascending (Oldest First)"
+              : "Sort Descending (Newest First)"
+        }
+        aria-label="Toggle sort direction"
+      >
+        {currentDir === "desc" ? (
+          <ArrowDown size={18} />
+        ) : (
+          <ArrowUp size={18} />
+        )}
+      </button>
     </div>
   );
 }

--- a/src/app/timeline/page.module.css
+++ b/src/app/timeline/page.module.css
@@ -346,3 +346,30 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+.iconButton {
+  background: transparent;
+  color: hsl(var(--foreground));
+  border: none;
+  width: 32px;
+  height: 32px;
+  border-radius: calc(var(--radius) - 2px);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.iconButton:hover:not(:disabled) {
+  background: hsl(var(--secondary));
+}
+
+.iconButton:active:not(:disabled) {
+  background: hsl(var(--accent));
+}
+
+.iconButton:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}

--- a/src/components/Lightbox.module.css
+++ b/src/components/Lightbox.module.css
@@ -507,3 +507,26 @@
     transform: rotate(360deg);
   }
 }
+
+.dateRow {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.dateRow + .dateRow {
+  margin-top: 10px;
+}
+
+.dateLabel {
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: hsl(var(--muted-foreground));
+  letter-spacing: 0.02em;
+}
+
+.dateValue {
+  font-size: 0.9rem;
+  color: hsl(var(--foreground));
+}

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -200,19 +200,23 @@ export default function Lightbox({
 
   if (!item) return null;
 
-  // Format date
-  const date = item.capturedAt
-    ? new Date(item.capturedAt)
-    : item.createdAt
-      ? new Date(item.createdAt)
-      : null;
+  // Format dates
+  const capturedDate = item.capturedAt ? new Date(item.capturedAt) : null;
+  const createdDate = item.createdAt ? new Date(item.createdAt) : null;
 
-  const formattedDate = date
-    ? date.toLocaleString(undefined, {
+  const formattedCapturedDate = capturedDate
+    ? capturedDate.toLocaleString(undefined, {
         dateStyle: "full",
         timeStyle: "medium",
       })
-    : "Unknown Date";
+    : "Unknown";
+
+  const formattedCreatedDate = createdDate
+    ? createdDate.toLocaleString(undefined, {
+        dateStyle: "full",
+        timeStyle: "medium",
+      })
+    : null;
 
   return (
     <div
@@ -442,8 +446,19 @@ export default function Lightbox({
         </div>
 
         <div className={styles.section}>
-          <h3 className={styles.sectionTitle}>Date</h3>
-          <div className={styles.sectionContent}>{formattedDate}</div>
+          <h3 className={styles.sectionTitle}>Date Details</h3>
+          <div className={styles.sectionContent}>
+            <div className={styles.dateRow}>
+              <span className={styles.dateLabel}>Original Post:</span>{" "}
+              <span className={styles.dateValue}>{formattedCapturedDate}</span>
+            </div>
+            {formattedCreatedDate && (
+              <div className={styles.dateRow}>
+                <span className={styles.dateLabel}>Imported to Library:</span>{" "}
+                <span className={styles.dateValue}>{formattedCreatedDate}</span>
+              </div>
+            )}
+          </div>
         </div>
 
         <div className={styles.section}>

--- a/src/lib/db/repositories/media.ts
+++ b/src/lib/db/repositories/media.ts
@@ -86,8 +86,13 @@ export async function getMediaItems(filters?: {
   const orderBys: SQL[] = [];
   let cursorCond: SQL | undefined;
 
-  // Use coalesce to get a numeric timestamp for sorting
-  const sortField = sql`COALESCE(${posts.createdAt}, ${mediaItems.capturedAt}, 0)`;
+  let sortField: SQL;
+  if (sortBy.startsWith("captured")) {
+    sortField = sql`COALESCE(${mediaItems.capturedAt}, ${mediaItems.createdAt}, 0)`;
+  } else {
+    sortField = sql`COALESCE(${mediaItems.createdAt}, 0)`;
+  }
+
   // biome-ignore lint/suspicious/noExplicitAny: Drizzle aliased columns conflict with raw SQL types in query builder select shape
   let sortValOutput: any = sortField;
 
@@ -104,7 +109,7 @@ export async function getMediaItems(filters?: {
         and(eq(rankCol, cursorSortVal), gt(mediaItems.id, cursorId)),
       );
     }
-  } else if (sortBy === "created-asc" || sortBy === "captured-asc") {
+  } else if (sortBy.endsWith("-asc")) {
     orderBys.push(asc(sortField), asc(mediaItems.id));
     if (
       cursorSortVal !== null &&
@@ -229,9 +234,16 @@ export async function getMediaItems(filters?: {
   let nextCursor: string | null = null;
   if (results.length === limit) {
     const lastItem = results[results.length - 1];
-    nextCursor = Buffer.from(
-      `${lastItem.sortVal}_${lastItem.item.id}`,
-    ).toString("base64");
+    const sortVal =
+      lastItem.sortVal instanceof Date
+        ? lastItem.sortVal.getTime()
+        : typeof lastItem.sortVal === "string"
+          ? Date.parse(lastItem.sortVal)
+          : Number(lastItem.sortVal || 0);
+
+    nextCursor = Buffer.from(`${sortVal}_${lastItem.item.id}`).toString(
+      "base64",
+    );
   }
 
   // Return the items minus the internal sortVal to match the previous structure as closely as possible

--- a/tests/timeline.spec.ts
+++ b/tests/timeline.spec.ts
@@ -86,9 +86,16 @@ test("timeline sorting interaction", async ({ page }) => {
   const sortSelect = page.locator("select").first();
   await expect(sortSelect).toBeVisible();
 
-  // Change sort to "Oldest First"
-  await sortSelect.selectOption("created-asc");
-  await expect(sortSelect).toHaveValue("created-asc");
+  // Change sort to "Imported to Library" (created)
+  await sortSelect.selectOption("created");
+  await expect(sortSelect).toHaveValue("created");
+
+  // Click the direction toggle button to switch to Ascending (Oldest First)
+  const dirToggle = page
+    .locator("button[aria-label='Toggle sort direction']")
+    .first();
+  await expect(dirToggle).toBeVisible();
+  await dirToggle.click();
 });
 
 test("timeline defaults to infinite scroll mode", async ({ page }) => {


### PR DESCRIPTION
### 1. Repository Sorting Corrections
- **File:** [media.ts]
- **Fix:** Fixed the date sorting logic.
  - When sorting by **Imported Date** (`created`), it now correctly sorts on `mediaItems.createdAt`.
  - When sorting by **Content Date** (`captured`), it now correctly sorts on `COALESCE(mediaItems.capturedAt, mediaItems.createdAt, 0)`.
  - Implemented dynamic direction sorting mapping based on the `asc` / `desc` suffixes sent by the UI.
  - Added robust parsing to ensure `lastItem.sortVal` is converted to a numeric timestamp in JS before base64 encoding to prevent cursor pagination mismatch bugs.

### 2. Gallery Sorting Control UX Enhancement
- **File:** [FilterBar.tsx]
- **Improvement:** 
  - Simplified the sorting dropdown options to the three main fields: "Imported to Library" (`created`), "Original Post Date" (`captured`), and "Relevance" (`relevance`).
  - Added a direction toggle button (`ArrowUp` or `ArrowDown` from Lucide-React) next to the dropdown select field.
  - Clicking this toggle button flips the direction of sorting (`asc` / `desc`).
  - Automatically disabled and ignored the toggle button when "Relevance" is active, ensuring relevance-based search results remain unaffected.

### 3. Lightbox date details display
- **Files:** 
  - [Lightbox.tsx]
  - [Lightbox.module.css]
- **Improvement:**
  - Read both existing date properties from `item` (`capturedAt` and `createdAt`).
  - Formatted both dates separately using standard locale options.
  - Replaced the single date row in the sidebar panel with a beautiful two-row layout:
    * **Original Post:** Date (or `Unknown` if null)
    * **Imported to Library:** Date
  - Added styling classes for `.dateRow`, `.dateLabel`, and `.dateValue` in `Lightbox.module.css` to match the glassmorphic aesthetics.
