### PR TITLE
#57 refetch post data button

### DIFF
--- a/drizzle/0010_even_rage.sql
+++ b/drizzle/0010_even_rage.sql
@@ -1,0 +1,25 @@
+CREATE TABLE `library_statistics` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`total_posts` integer DEFAULT 0 NOT NULL,
+	`total_media_items` integer DEFAULT 0 NOT NULL,
+	`total_tags` integer DEFAULT 0 NOT NULL,
+	`total_users` integer DEFAULT 0 NOT NULL,
+	`total_extractors` integer DEFAULT 0 NOT NULL,
+	`storage_bytes` integer DEFAULT 0 NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `statistics_history` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`date` text NOT NULL,
+	`date_type` text DEFAULT 'import' NOT NULL,
+	`total_posts` integer DEFAULT 0 NOT NULL,
+	`total_media_items` integer DEFAULT 0 NOT NULL,
+	`total_tags` integer DEFAULT 0 NOT NULL,
+	`total_users` integer DEFAULT 0 NOT NULL,
+	`total_extractors` integer DEFAULT 0 NOT NULL,
+	`storage_bytes` integer DEFAULT 0 NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_statistics_history_date` ON `statistics_history` (`date`,`date_type`);--> statement-breakpoint
+ALTER TABLE `posts` ADD `is_source_deleted` integer DEFAULT false;

--- a/drizzle/meta/0010_snapshot.json
+++ b/drizzle/meta/0010_snapshot.json
@@ -1,0 +1,1587 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f776d45a-cc18-403b-a276-745ac9abcc96",
+  "prevId": "04b71ce3-f609-4a35-ad3c-338146f7562f",
+  "tables": {
+    "gallerydl_extractor_types": {
+      "name": "gallerydl_extractor_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "library_statistics": {
+      "name": "library_statistics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_media_items": {
+          "name": "total_media_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tags": {
+          "name": "total_tags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_extractors": {
+          "name": "total_extractors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "media_items_post_id_posts_id_fk": {
+          "name": "media_items_post_id_posts_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pixiv_users": {
+      "name": "pixiv_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_followed": {
+          "name": "is_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_accept_request": {
+          "name": "is_accept_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlist_items": {
+      "name": "playlist_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "playlist_items_playlist_id_playlists_id_fk": {
+          "name": "playlist_items_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_items_media_item_id_media_items_id_fk": {
+          "name": "playlist_items_media_item_id_media_items_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "media_items",
+          "columnsFrom": ["media_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_gelbooruv02": {
+      "name": "post_details_gelbooruv02",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "md5": {
+          "name": "md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_gelbooruv02_post_id_posts_id_fk": {
+          "name": "post_details_gelbooruv02_post_id_posts_id_fk",
+          "tableFrom": "post_details_gelbooruv02",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_pixiv": {
+      "name": "post_details_pixiv",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restrict": {
+          "name": "restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x_restrict": {
+          "name": "x_restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sanity_level": {
+          "name": "sanity_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_view": {
+          "name": "total_view",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_bookmarks": {
+          "name": "total_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_bookmarked": {
+          "name": "is_bookmarked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_ai_type": {
+          "name": "illust_ai_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_book_style": {
+          "name": "illust_book_style",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_pixiv_post_id_posts_id_fk": {
+          "name": "post_details_pixiv_post_id_posts_id_fk",
+          "tableFrom": "post_details_pixiv",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_twitter": {
+      "name": "post_details_twitter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retweet_id": {
+          "name": "retweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_id": {
+          "name": "reply_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive_flags": {
+          "name": "sensitive_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite_count": {
+          "name": "favorite_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_count": {
+          "name": "quote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retweet_count": {
+          "name": "retweet_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bookmark_count": {
+          "name": "bookmark_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_details_twitter_post_id_posts_id_fk": {
+          "name": "post_details_twitter_post_id_posts_id_fk",
+          "tableFrom": "post_details_twitter",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_tag_id_post_id_pk": {
+          "columns": ["tag_id", "post_id"],
+          "name": "post_tags_tag_id_post_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_source_id": {
+          "name": "json_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_source_id": {
+          "name": "internal_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_path": {
+          "name": "metadata_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_source_deleted": {
+          "name": "is_source_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "posts_internal_source_id_sources_id_fk": {
+          "name": "posts_internal_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["internal_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_history": {
+      "name": "scan_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_type": {
+          "name": "scan_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "files_processed": {
+          "name": "files_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_added": {
+          "name": "files_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_updated": {
+          "name": "files_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_deleted": {
+          "name": "files_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scrape_history": {
+      "name": "scrape_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_downloaded": {
+          "name": "files_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_processed": {
+          "name": "posts_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_speed": {
+          "name": "average_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scrape_history_source_id_sources_id_fk": {
+          "name": "scrape_history_source_id_sources_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_history_task_id_scraping_tasks_id_fk": {
+          "name": "scrape_history_task_id_scraping_tasks_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "scraping_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraper_download_logs": {
+      "name": "scraper_download_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scraper_download_logs_file_path_unique": {
+          "name": "scraper_download_logs_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "scraper_download_logs_source_id_sources_id_fk": {
+          "name": "scraper_download_logs_source_id_sources_id_fk",
+          "tableFrom": "scraper_download_logs",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraping_tasks": {
+      "name": "scraping_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_options": {
+          "name": "download_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "scraping_tasks_source_id_sources_id_fk": {
+          "name": "scraping_tasks_source_id_sources_id_fk",
+          "tableFrom": "scraping_tasks",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sources_extractor_type_gallerydl_extractor_types_id_fk": {
+          "name": "sources_extractor_type_gallerydl_extractor_types_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "gallerydl_extractor_types",
+          "columnsFrom": ["extractor_type"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "statistics_history": {
+      "name": "statistics_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_type": {
+          "name": "date_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'import'"
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_media_items": {
+          "name": "total_media_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tags": {
+          "name": "total_tags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_extractors": {
+          "name": "total_extractors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_statistics_history_date": {
+          "name": "idx_statistics_history_date",
+          "columns": ["date", "date_type"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twitter_users": {
+      "name": "twitter_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nick": {
+          "name": "nick",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_banner": {
+          "name": "profile_banner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favourites_count": {
+          "name": "favourites_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "friends_count": {
+          "name": "friends_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listed_count": {
+          "name": "listed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_count": {
+          "name": "media_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "statuses_count": {
+          "name": "statuses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1780249731359,
       "tag": "0009_statistics_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1780342473153,
+      "tag": "0010_even_rage",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/actions/gallery.ts
+++ b/src/app/actions/gallery.ts
@@ -20,6 +20,15 @@ export async function deleteMediaItems(ids: number[], deleteFiles: boolean) {
   return result;
 }
 
+function isHostnameInDomain(hostname: string, domain: string): boolean {
+  const normalizedHost = hostname.toLowerCase();
+  const normalizedDomain = domain.toLowerCase();
+  return (
+    normalizedHost === normalizedDomain ||
+    normalizedHost.endsWith(`.${normalizedDomain}`)
+  );
+}
+
 export async function refetchPostData(postIds: number[]) {
   console.log(
     `[GalleryActions] Refetching post data for ${postIds.length} posts`,
@@ -62,15 +71,15 @@ export async function refetchPostData(postIds: number[]) {
             const parsed = new URL(post.url);
             const hostname = parsed.hostname.toLowerCase();
             if (
-              hostname.includes("twitter.com") ||
-              hostname.includes("x.com")
+              isHostnameInDomain(hostname, "twitter.com") ||
+              isHostnameInDomain(hostname, "x.com")
             ) {
               type = "twitter";
-            } else if (hostname.includes("pixiv.net")) {
+            } else if (isHostnameInDomain(hostname, "pixiv.net")) {
               type = "pixiv";
             } else if (
-              hostname.includes("gelbooru.com") ||
-              hostname.includes("safebooru.org")
+              isHostnameInDomain(hostname, "gelbooru.com") ||
+              isHostnameInDomain(hostname, "safebooru.org")
             ) {
               type = "gelbooruv02";
             }
@@ -145,7 +154,7 @@ export async function refetchPostData(postIds: number[]) {
         successCount++;
       }
     } catch (err) {
-      console.error(`[GalleryActions] Failed to refetch post ${postId}:`, err);
+      console.error("[GalleryActions] Failed to refetch post %s:", postId, err);
     }
   }
 

--- a/src/app/actions/gallery.ts
+++ b/src/app/actions/gallery.ts
@@ -19,3 +19,143 @@ export async function deleteMediaItems(ids: number[], deleteFiles: boolean) {
   revalidatePath("/");
   return result;
 }
+
+export async function refetchPostData(postIds: number[]) {
+  console.log(
+    `[GalleryActions] Refetching post data for ${postIds.length} posts`,
+  );
+  let successCount = 0;
+  let deletedCount = 0;
+
+  const { db } = await import("@/lib/db");
+  const { posts, sources } = await import("@/lib/db/schema");
+  const { eq } = await import("drizzle-orm");
+  const { scraperManager } = await import("@/lib/scrapers/manager");
+  const { paths } = await import("@/lib/config");
+
+  for (const postId of postIds) {
+    try {
+      const post = await db.query.posts.findFirst({
+        where: eq(posts.id, postId),
+      });
+
+      if (!post?.url) {
+        console.warn(
+          `[GalleryActions] Post ${postId} not found or has no URL, skipping`,
+        );
+        continue;
+      }
+
+      let sourceId = post.internalSourceId;
+      if (!sourceId) {
+        // Find existing source with the same URL
+        const existingSource = await db.query.sources.findFirst({
+          where: eq(sources.url, post.url),
+        });
+
+        if (existingSource) {
+          sourceId = existingSource.id;
+        } else {
+          // Determine extractor type from url
+          let type = "gallery-dl";
+          try {
+            const parsed = new URL(post.url);
+            const hostname = parsed.hostname.toLowerCase();
+            if (
+              hostname.includes("twitter.com") ||
+              hostname.includes("x.com")
+            ) {
+              type = "twitter";
+            } else if (hostname.includes("pixiv.net")) {
+              type = "pixiv";
+            } else if (
+              hostname.includes("gelbooru.com") ||
+              hostname.includes("safebooru.org")
+            ) {
+              type = "gelbooruv02";
+            }
+          } catch {}
+
+          const res = await db
+            .insert(sources)
+            .values({
+              url: post.url,
+              extractorType: type,
+              name: `Refetch: ${post.title || post.url}`,
+            })
+            .returning({ id: sources.id });
+          sourceId = res[0].id;
+        }
+
+        // Associate post with source
+        await db
+          .update(posts)
+          .set({ internalSourceId: sourceId })
+          .where(eq(posts.id, postId));
+      }
+
+      console.log(
+        `[GalleryActions] Running scrape for post ${postId} (source ${sourceId}) URL: ${post.url}`,
+      );
+
+      const result = await scraperManager.startScrape(
+        sourceId,
+        "gallery-dl",
+        post.url,
+        paths.downloads,
+        { mode: "quick" },
+      );
+
+      if (!result) {
+        console.warn(
+          `[GalleryActions] Failed to start scrape or scrape already active for post ${postId}`,
+        );
+        continue;
+      }
+
+      const output = result.output || "";
+      const errorMsg = result.error || "";
+      const fullText = `${output}\n${errorMsg}`.toLowerCase();
+
+      // Check for remote deletion / private / suspension signatures
+      const isDeleted =
+        fullText.includes("404") ||
+        fullText.includes("not found") ||
+        fullText.includes("does not exist") ||
+        fullText.includes("deleted") ||
+        fullText.includes("is not available") ||
+        fullText.includes("suspended") ||
+        fullText.includes("403") ||
+        fullText.includes("410");
+
+      if (isDeleted) {
+        console.log(
+          `[GalleryActions] Post ${postId} remote source is deleted. Marking.`,
+        );
+        await db
+          .update(posts)
+          .set({ isSourceDeleted: true })
+          .where(eq(posts.id, postId));
+        deletedCount++;
+      } else {
+        await db
+          .update(posts)
+          .set({ isSourceDeleted: false })
+          .where(eq(posts.id, postId));
+        successCount++;
+      }
+    } catch (err) {
+      console.error(`[GalleryActions] Failed to refetch post ${postId}:`, err);
+    }
+  }
+
+  revalidatePath("/gallery");
+  revalidatePath("/timeline");
+  revalidatePath("/");
+
+  return {
+    successCount,
+    deletedCount,
+    totalCount: postIds.length,
+  };
+}

--- a/src/app/gallery/components/BulkActionBar.tsx
+++ b/src/app/gallery/components/BulkActionBar.tsx
@@ -6,14 +6,18 @@ interface BulkActionBarProps {
   selectedCount: number;
   onBulkDelete: (deleteFiles: boolean) => void;
   onAddToPlaylist: () => void;
+  onBulkRefetch: () => void;
   deleting: boolean;
+  refetching: boolean;
 }
 
 export default function BulkActionBar({
   selectedCount,
   onBulkDelete,
   onAddToPlaylist,
+  onBulkRefetch,
   deleting,
+  refetching,
 }: BulkActionBarProps) {
   if (selectedCount === 0) return null;
 
@@ -24,8 +28,16 @@ export default function BulkActionBar({
         <button
           type="button"
           className={styles.playlistButton}
+          onClick={onBulkRefetch}
+          disabled={deleting || refetching}
+        >
+          {refetching ? "Refetching..." : "Refetch Post Data"}
+        </button>
+        <button
+          type="button"
+          className={styles.playlistButton}
           onClick={onAddToPlaylist}
-          disabled={deleting}
+          disabled={deleting || refetching}
         >
           Add to Playlist
         </button>
@@ -33,7 +45,7 @@ export default function BulkActionBar({
           type="button"
           className={styles.secondaryDeleteButton}
           onClick={() => onBulkDelete(false)}
-          disabled={deleting}
+          disabled={deleting || refetching}
         >
           {deleting ? "..." : "Delete from DB"}
         </button>
@@ -41,7 +53,7 @@ export default function BulkActionBar({
           type="button"
           className={styles.deleteButton}
           onClick={() => onBulkDelete(true)}
-          disabled={deleting}
+          disabled={deleting || refetching}
         >
           {deleting ? "Deleting..." : "Delete from Disk & DB"}
         </button>

--- a/src/app/gallery/components/GalleryItem.tsx
+++ b/src/app/gallery/components/GalleryItem.tsx
@@ -64,6 +64,15 @@ export default function GalleryItem({
         </div>
       )}
 
+      {row.post?.isSourceDeleted && (
+        <div
+          className={styles.deletedSourceBadge}
+          title="Post is no longer available on remote source"
+        >
+          🚫 Deleted from Source
+        </div>
+      )}
+
       {item.mediaType === "video" ? (
         <>
           <video

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { deleteMediaItems } from "@/app/actions/gallery";
+import { deleteMediaItems, refetchPostData } from "@/app/actions/gallery";
 import BulkActionBar from "@/app/gallery/components/BulkActionBar";
 import FilterBar from "@/app/gallery/components/FilterBar";
 import GalleryItem from "@/app/gallery/components/GalleryItem";
@@ -86,6 +86,7 @@ function GalleryPageContent({
 }) {
   const [columnCount, setColumnCount] = useState(4);
   const [deleting, setDeleting] = useState(false);
+  const [refetching, setRefetching] = useState(false);
   const [isAddToPlaylistOpen, setIsAddToPlaylistOpen] = useState(false);
 
   const {
@@ -179,6 +180,45 @@ function GalleryPageContent({
     }
   }
 
+  async function handleBulkRefetch() {
+    if (selectedCount === 0) return;
+
+    // Find the unique post IDs of selected media items
+    const selectedPostIds = new Set<number>();
+    for (const group of items) {
+      for (const gi of group.groupItems) {
+        if (selectedIds.has(gi.item.id) && gi.post?.id) {
+          selectedPostIds.add(gi.post.id);
+        }
+      }
+    }
+
+    const postIds = Array.from(selectedPostIds);
+    if (postIds.length === 0) {
+      alert("No posts with remote URLs are selected.");
+      return;
+    }
+
+    setRefetching(true);
+    try {
+      const res = await refetchPostData(postIds);
+      alert(
+        `Refetch complete: ${res.successCount} succeeded, ${res.deletedCount} remote sources were deleted/unavailable.`,
+      );
+      clearSelection();
+      await refresh();
+    } catch (err) {
+      alert(`Failed to refetch post data: ${err}`);
+    } finally {
+      setRefetching(false);
+    }
+  }
+
+  async function handleRefetchSingle(postId: number) {
+    await refetchPostData([postId]);
+    await refresh();
+  }
+
   const currentGroup = selectedIndex !== null ? items[selectedIndex] : null;
   const currentItemRow = currentGroup
     ? currentGroup.groupItems[mediaIndex]
@@ -191,7 +231,9 @@ function GalleryPageContent({
           selectedCount={selectedCount}
           onBulkDelete={handleBulkDelete}
           onAddToPlaylist={() => setIsAddToPlaylistOpen(true)}
+          onBulkRefetch={handleBulkRefetch}
           deleting={deleting}
+          refetching={refetching}
         />
       )}
 
@@ -303,6 +345,7 @@ function GalleryPageContent({
           onNext={nextLightbox}
           onPrev={prevLightbox}
           onDelete={handleDeleteItem}
+          onRefetch={handleRefetchSingle}
           loopVideos={loopVideos}
           isPageLoading={isPageLoading}
         />

--- a/src/app/gallery/page.module.css
+++ b/src/app/gallery/page.module.css
@@ -376,3 +376,20 @@
   flex: 1;
   min-width: 0;
 }
+
+.deletedSourceBadge {
+  position: absolute;
+  bottom: 0.5rem;
+  left: 0.5rem;
+  background: hsl(var(--color-danger) / 0.9);
+  color: white;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  z-index: 5;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
+}

--- a/src/components/Lightbox.module.css
+++ b/src/components/Lightbox.module.css
@@ -530,3 +530,56 @@
   font-size: 0.9rem;
   color: hsl(var(--foreground));
 }
+
+.sourceDeletedBanner {
+  background: hsl(var(--color-danger) / 0.15);
+  color: hsl(var(--color-danger));
+  border: 1px solid hsl(var(--color-danger) / 0.3);
+  padding: 0.75rem;
+  border-radius: var(--radius);
+  margin-bottom: 1rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  line-height: 1.4;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.refetchButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 10px;
+  background: hsl(var(--color-info));
+  color: white;
+  border: none;
+  border-radius: var(--radius);
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  margin-bottom: 10px;
+  gap: 8px;
+}
+
+.refetchButton:hover:not(:disabled) {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+.refetchButton:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.refetchSpinner {
+  width: 16px;
+  height: 16px;
+  border: 2px solid rgba(255, 255, 255, 0.3);
+  border-top-color: white;
+  border-radius: 50%;
+  animation: spin 0.8s linear infinite;
+  display: inline-block;
+}

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -29,6 +29,7 @@ interface LightboxProps {
   onNext?: () => void;
   onPrev?: () => void;
   onDelete?: (id: number, deleteFile: boolean) => void;
+  onRefetch?: (postId: number) => Promise<void>;
   loopVideos?: boolean;
   isPageLoading?: boolean;
 }
@@ -45,6 +46,7 @@ export default function Lightbox({
   onNext,
   onPrev,
   onDelete,
+  onRefetch,
   loopVideos,
   isPageLoading = false,
 }: LightboxProps) {
@@ -52,7 +54,20 @@ export default function Lightbox({
   const [showInfo, setShowInfo] = useState(true);
   const [pixivTags, setPixivTags] = useState<{ name: string }[]>([]);
   const [isRecentlyMounted, setIsRecentlyMounted] = useState(true);
+  const [refetching, setRefetching] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
+
+  async function handleRefetch() {
+    if (!onRefetch || !row.post?.id) return;
+    setRefetching(true);
+    try {
+      await onRefetch(row.post.id);
+    } catch (err) {
+      alert(`Failed to refetch post data: ${err}`);
+    } finally {
+      setRefetching(false);
+    }
+  }
 
   // Playlists State
   const [associatedPlaylists, setAssociatedPlaylists] = useState<
@@ -393,6 +408,13 @@ export default function Lightbox({
           </h2>
         </div>
 
+        {row.post?.isSourceDeleted && (
+          <div className={styles.sourceDeletedBanner}>
+            ⚠️ This post is no longer available on the remote platform (deleted
+            or private).
+          </div>
+        )}
+
         {user && (
           <div className={`${styles.section} ${styles.userCard}`}>
             {user.profileImage && (
@@ -612,6 +634,22 @@ export default function Lightbox({
         {(row.post?.url || (tweet?.tweetId && user) || pixiv?.pixivId) && (
           <div className={styles.section}>
             <h3 className={styles.sectionTitle}>Source</h3>
+            {onRefetch && row.post?.id && (
+              <button
+                type="button"
+                className={styles.refetchButton}
+                onClick={handleRefetch}
+                disabled={refetching}
+              >
+                {refetching ? (
+                  <>
+                    <span className={styles.refetchSpinner} /> Refetching...
+                  </>
+                ) : (
+                  "Refetch Post Data"
+                )}
+              </button>
+            )}
             {row.post?.url && (
               <a
                 href={row.post.url}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -145,6 +145,9 @@ export const posts = sqliteTable("posts", {
   content: text("content"), // caption, body, etc.
   url: text("url"), // Link to original post
   metadataPath: text("metadata_path"), // Path to the JSON metadata file
+  isSourceDeleted: integer("is_source_deleted", { mode: "boolean" }).default(
+    false,
+  ),
   createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
     () => new Date(),
   ),

--- a/src/lib/library/processors/gelbooru.ts
+++ b/src/lib/library/processors/gelbooru.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { and, eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { postDetailsGelbooruV02, posts, postTags, tags } from "@/lib/db/schema";
 import type { IMetadataProcessor } from "@/lib/library/processors/base";
 import type { ProcessorContext, ProcessTask } from "@/lib/library/types";
@@ -100,11 +100,60 @@ export class GelbooruProcessor implements IMetadataProcessor<GelbooruMeta> {
         });
       } else {
         postId = existingPosts.get(key) || null;
-        if (postId && internalSourceId) {
+        if (postId) {
+          let title = null;
+          if (meta.title) title = meta.title;
+          else if (meta.tags) {
+            const tagList =
+              typeof meta.tags === "string" ? meta.tags.split(" ") : meta.tags;
+            const charTags = tagList.filter((t: string) =>
+              t.startsWith("character:"),
+            );
+            const copyTags = tagList.filter((t: string) =>
+              t.startsWith("copyright:"),
+            );
+            if (charTags.length > 0)
+              title = charTags[0].replace("character:", "");
+            else if (copyTags.length > 0)
+              title = copyTags[0].replace("copyright:", "");
+          }
+
+          const updateSet: Record<string, unknown> = {
+            date: meta.created_at || meta.date,
+            title: title,
+            content: meta.source,
+            url: `https://gelbooru.com/index.php?page=post&s=view&id=${idStr}`,
+          };
+          if (internalSourceId) {
+            updateSet.internalSourceId = internalSourceId;
+          }
+          if (task.jsonPath) {
+            updateSet.metadataPath = path
+              .relative(path.join(process.cwd(), "public"), task.jsonPath)
+              .split(path.sep)
+              .join("/");
+          }
+          await tx.update(posts).set(updateSet).where(eq(posts.id, postId));
+
+          const parsedTags: string[] | null =
+            typeof meta.tags === "string"
+              ? meta.tags.split(" ")
+              : Array.isArray(meta.tags)
+                ? meta.tags
+                : null;
+
           await tx
-            .update(posts)
-            .set({ internalSourceId })
-            .where(and(eq(posts.id, postId), isNull(posts.internalSourceId)));
+            .update(postDetailsGelbooruV02)
+            .set({
+              width: meta.width,
+              height: meta.height,
+              score: meta.score,
+              rating: meta.rating,
+              source: meta.source,
+              md5: meta.md5,
+              tags: parsedTags ? JSON.stringify(parsedTags) : null,
+            })
+            .where(eq(postDetailsGelbooruV02.postId, postId));
         }
       }
     }

--- a/src/lib/library/processors/pixiv.ts
+++ b/src/lib/library/processors/pixiv.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { and, eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import {
   pixivUsers,
   postDetailsPixiv,
@@ -154,18 +154,48 @@ export class PixivProcessor implements IMetadataProcessor<PixivMeta> {
       } else {
         postId = existingPosts.get(key) || null;
         if (postId) {
+          const updateSet: Record<string, unknown> = {
+            title: meta.title,
+            content: meta.caption,
+            date: meta.date || meta.create_date,
+            url: `https://www.pixiv.net/artworks/${pid}`,
+          };
           if (internalSourceId) {
-            await tx
-              .update(posts)
-              .set({ internalSourceId })
-              .where(and(eq(posts.id, postId), isNull(posts.internalSourceId)));
+            updateSet.internalSourceId = internalSourceId;
           }
           if (meta.visible === false) {
-            await tx
-              .update(posts)
-              .set({ deletedAt: new Date() })
-              .where(and(eq(posts.id, postId), isNull(posts.deletedAt)));
+            updateSet.deletedAt = new Date();
           }
+          if (task.jsonPath) {
+            updateSet.metadataPath = path
+              .relative(path.join(process.cwd(), "public"), task.jsonPath)
+              .split(path.sep)
+              .join("/");
+          }
+          await tx.update(posts).set(updateSet).where(eq(posts.id, postId));
+
+          await tx
+            .update(postDetailsPixiv)
+            .set({
+              width: meta.width,
+              height: meta.height,
+              pageCount: meta.page_count,
+              restrict: meta.restrict,
+              xRestrict: meta.x_restrict,
+              sanityLevel: meta.sanity_level,
+              totalView: meta.total_view,
+              totalBookmarks: meta.total_bookmarks,
+              isBookmarked: meta.is_bookmarked,
+              visible: meta.visible,
+              isMuted: meta.is_muted,
+              illustAiType: meta.illust_ai_type,
+              illustBookStyle: meta.illust_book_style,
+              tags: meta.tags,
+              category: "pixiv",
+              subcategory: meta.subcategory,
+              type: meta.type,
+            })
+            .where(eq(postDetailsPixiv.postId, postId));
         }
       }
     }

--- a/src/lib/library/processors/twitter.ts
+++ b/src/lib/library/processors/twitter.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { and, eq, isNull } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import { postDetailsTwitter, posts, twitterUsers } from "@/lib/db/schema";
 import type { IMetadataProcessor } from "@/lib/library/processors/base";
 import type { ProcessorContext, ProcessTask } from "@/lib/library/types";
@@ -160,12 +160,47 @@ export class TwitterProcessor implements IMetadataProcessor<TwitterMeta> {
         return postId;
       } else {
         const postId = existingPosts.get(key) || null;
-        if (postId && internalSourceId) {
-          // Update internalSourceId if it's currently null
+        if (postId) {
+          const updateSet: Record<string, unknown> = {
+            title: userObj.nick || userObj.name,
+            content: meta.content,
+            date: meta.date,
+            url: `https://x.com/${userObj.name || userObj.nick || "i"}/status/${tid}`,
+          };
+          if (internalSourceId) {
+            updateSet.internalSourceId = internalSourceId;
+          }
+          if (task.jsonPath) {
+            updateSet.metadataPath = path
+              .relative(path.join(process.cwd(), "public"), task.jsonPath)
+              .split(path.sep)
+              .join("/");
+          }
+          await tx.update(posts).set(updateSet).where(eq(posts.id, postId));
+
           await tx
-            .update(posts)
-            .set({ internalSourceId })
-            .where(and(eq(posts.id, postId), isNull(posts.internalSourceId)));
+            .update(postDetailsTwitter)
+            .set({
+              retweetId: meta.retweet_id ? String(meta.retweet_id) : null,
+              quoteId: meta.quote_id ? String(meta.quote_id) : null,
+              replyId: meta.reply_id ? String(meta.reply_id) : null,
+              conversationId: meta.conversation_id
+                ? String(meta.conversation_id)
+                : null,
+              lang: meta.lang,
+              source: meta.source,
+              sensitive: meta.sensitive,
+              sensitiveFlags: meta.sensitive_flags,
+              favoriteCount: meta.favorite_count,
+              quoteCount: meta.quote_count,
+              replyCount: meta.reply_count,
+              retweetCount: meta.retweet_count,
+              bookmarkCount: meta.bookmark_count,
+              viewCount: meta.view_count,
+              category: "twitter",
+              subcategory: "tweet",
+            })
+            .where(eq(postDetailsTwitter.postId, postId));
         }
         return postId;
       }

--- a/src/lib/scrapers/manager.ts
+++ b/src/lib/scrapers/manager.ts
@@ -213,7 +213,7 @@ class ScraperManager {
 
     this.activeScrapes.set(sourceId, { process: child, status, strategy });
 
-    promise
+    return promise
       .then(async (result) => {
         let logMsg = result.error || result.output || "";
         if (logMsg.length > 200) {
@@ -307,6 +307,8 @@ class ScraperManager {
             this.activeScrapes.delete(sourceId);
           }, 30000); // 30 seconds
         }
+
+        return result;
       })
       .catch(async (err) => {
         console.error(`[ScraperManager] ERROR for source ID:`, sourceId, err);
@@ -327,6 +329,8 @@ class ScraperManager {
         console.log(
           `[ScraperManager] Scrape failed for source ${sourceId}. No incremental scan queued — use manual full scan if needed.`,
         );
+
+        throw err;
       });
   }
 


### PR DESCRIPTION
# Walkthrough - Refetch Post Data & Remote Deletion Handling (Issue #57)

I have successfully implemented the "Refetch Post Data" feature, allowing single-post or multi-post refetches from both the gallery bulk action bar and the lightbox. I also added support to elegantly detect and label posts that have been deleted or made unavailable on the remote platforms (Twitter, Pixiv, etc.).

## Changes Implemented

### 1. Database Schema & Migration
- Added the `isSourceDeleted` boolean column to the `posts` table in [schema.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/schema.ts#L148):
  ```ts
  isSourceDeleted: integer("is_source_deleted", { mode: "boolean" }).default(false)
  ```
- Generated a schema migration `0010_even_rage.sql` using Drizzle Kit.
- Executed `initDb()` programmatically to safely apply the migration to the active local SQLite database.

### 2. ScraperManager Pipeline Enhancement
- Modified `startScrape` inside [manager.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/scrapers/manager.ts#L216) to return the runner promise chain.
- This allows calling contexts to `await scraperManager.startScrape(...)` and inspect full execution results, logs, errors, and downloaded files when a scrape completes.

### 3. Server Actions
- Implemented the `refetchPostData` server action inside [gallery.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/actions/gallery.ts#L24):
  - Fetches target posts sequentially to guarantee database safety and serial command execution.
  - Generates or binds active target sources if missing from the post to record scrape history and log outputs correctly.
  - Automatically scans stderr and stdout CLI logs for remote unavailability signatures (`404`, `403`, `410`, `"not found"`, `"suspended"`, etc.).
  - Marks `isSourceDeleted` in the database dynamically.
  - Triggers cached route revalidation across gallery, timeline, and main pages.

### 4. Polished UI Components
- **BulkActionBar**: Added a premium-styled "Refetch Post Data" button [BulkActionBar.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/components/BulkActionBar.tsx#L25) when items are selected, displaying a disabled loading state during execution.
- **Gallery Card Overlay**: Added a vibrant, bottom-left danger-colored badge `🚫 Deleted from Source` [GalleryItem.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/components/GalleryItem.tsx#L67) if `isSourceDeleted` is `true`. Styled in [page.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/page.module.css#L379).
- **Lightbox Alerts**:
  - Rendered a transparent error banner `⚠️ This post is no longer available on the remote platform (deleted or private)` [Lightbox.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.tsx#L393) at the top of the sidebar when viewing deleted posts.
  - Added a "Refetch Post Data" action button [Lightbox.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.tsx#L611) within the sidebar "Source" section, including a loading spinner state.
  - Styled both elements in [Lightbox.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.module.css#L534) using thematic transparent styles matching the glassmorphic environment.
- **Page Client Integrations**: Hooked up selection mappings, refetching states, and refresh methods inside [page-client.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/page-client.tsx#L179).

### 5. Existing Post Metadata Processor Updates
- Discovered that the metadata processors ([pixiv.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/pixiv.ts), [twitter.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/twitter.ts), and [gelbooru.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/gelbooru.ts)) were previously configured to only perform `INSERT` statements when a post was brand new, completely skipping updates to all metadata fields if the post already existed.
- Modified the `else` blocks in all three processors to perform a comprehensive database `update` on the `posts` table (including `content` which holds the caption, `title`, `date`, `url`, and `metadataPath`) and their respective platform-specific details tables (`postDetailsPixiv`, `postDetailsTwitter`, `postDetailsGelbooruV02`) upon scanning/refetching.
- This ensures that refetching missing metadata (like Pixiv captions) now correctly overwrites and populates the database and displays it instantly in the UI.