### PR TITLE
#72 search autocomplete

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -218,6 +218,8 @@ Additionally, `instrumentation.ts` registers global `uncaughtException` and `unh
 
 **Full-Text Search**: The `posts` table is backed by a SQLite FTS5 virtual table. Column aliases and the filter allowlist are maintained in [`src/lib/utils/search-parser.ts`](./src/lib/utils/search-parser.ts).
 
+**Search Autocomplete**: Implements a Discord-style two-phase search suggestions dropdown (suggesting filter columns and matching database values) driven by `useSearchAutocomplete`, a dedicated repository (`src/lib/db/repositories/autocomplete.ts`), and the `/api/autocomplete` Route Handler. Typing/selection queries are debounced, and live-search pagination refetches are suppressed while the autocomplete popover is active to minimize overhead.
+
 ### 3.3 Scraping Subsystem
 
 **Location**: [`src/lib/scrapers/`](./src/lib/scrapers/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,7 @@ Common UI logic is extracted into `src/hooks/`:
 | `useInfiniteScroll` | Manages IntersectionObserver sentinel for paginated feeds | Gallery, Timeline |
 | `useLightbox` | Lightbox open/close/navigate state | Gallery, Timeline |
 | `usePaginatedData` | Generic cursor-based pagination + fetch | Gallery, Timeline, Playlists |
+| `useSearchAutocomplete` | Manages search query autocomplete dropdown state and keys | Gallery, Timeline |
 | `useSelection` | Selection state (toggle, select-all, clear, group selection) | Gallery, Sources |
 
 - **Rule**: When building a new page with selection, search, or lightbox behavior, consume these hooks rather than reimplementing the logic inline.
@@ -103,6 +104,7 @@ Frontend types are in `src/types/`:
 | File | Contains |
 |------|----------|
 | `media.ts` | `MediaItem`, `GalleryGroup`, `GalleryRow` |
+| `autocomplete.ts` | `AutocompleteSuggestion`, `AutocompleteResponse` definitions |
 | `playlist.ts` | `Playlist`, playlist-related types |
 | `posts.ts` | `TimelinePost`, post-related types |
 | `settings.ts` | `SystemSettings`, `AppSettings` definitions |

--- a/src/app/api/autocomplete/route.ts
+++ b/src/app/api/autocomplete/route.ts
@@ -1,0 +1,67 @@
+import { type NextRequest, NextResponse } from "next/server";
+import {
+  autocompleteContent,
+  autocompleteHandle,
+  autocompleteTag,
+  autocompleteTitle,
+  autocompleteUser,
+} from "@/lib/db/repositories/autocomplete";
+import type {
+  AutocompleteResponse,
+  AutocompleteSuggestion,
+} from "@/types/autocomplete";
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  const column = searchParams.get("column")?.toLowerCase();
+  const q = searchParams.get("q") || "";
+  const limitStr = searchParams.get("limit") || "8";
+  const limit = Math.max(1, Math.min(50, parseInt(limitStr, 10) || 8));
+
+  if (!column) {
+    return NextResponse.json({ suggestions: [] } as AutocompleteResponse);
+  }
+
+  let suggestions: AutocompleteSuggestion[] = [];
+
+  try {
+    switch (column) {
+      case "tag":
+        suggestions = await autocompleteTag(q, limit);
+        break;
+      case "user":
+        suggestions = await autocompleteUser(q, limit);
+        break;
+      case "handle":
+        suggestions = await autocompleteHandle(q, limit);
+        break;
+      case "title":
+        suggestions = await autocompleteTitle(q, limit);
+        break;
+      case "content":
+        suggestions = await autocompleteContent(q, limit);
+        break;
+      case "source":
+      case "extractor": {
+        // For source and extractor, return static values matching posts.extractorType
+        const staticValues = ["twitter", "pixiv", "gelbooruv02"];
+        suggestions = staticValues
+          .filter((v) => v.startsWith(q.toLowerCase()))
+          .map((v) => ({
+            value: v,
+            label: v,
+            type: "value" as const,
+          }));
+        break;
+      }
+      default:
+        suggestions = [];
+    }
+  } catch (error) {
+    console.error("Autocomplete API Error:", error);
+    // Return empty suggestions array on error to fail gracefully in the UI
+    return NextResponse.json({ suggestions: [] } as AutocompleteResponse);
+  }
+
+  return NextResponse.json({ suggestions } as AutocompleteResponse);
+}

--- a/src/app/api/autocomplete/route.ts
+++ b/src/app/api/autocomplete/route.ts
@@ -17,6 +17,7 @@ export async function GET(request: NextRequest) {
   const q = searchParams.get("q") || "";
   const limitStr = searchParams.get("limit") || "8";
   const limit = Math.max(1, Math.min(50, parseInt(limitStr, 10) || 8));
+  const context = searchParams.get("context") || undefined;
 
   if (!column) {
     return NextResponse.json({ suggestions: [] } as AutocompleteResponse);
@@ -27,7 +28,7 @@ export async function GET(request: NextRequest) {
   try {
     switch (column) {
       case "tag":
-        suggestions = await autocompleteTag(q, limit);
+        suggestions = await autocompleteTag(q, limit, context);
         break;
       case "user":
         suggestions = await autocompleteUser(q, limit);

--- a/src/app/gallery/components/FilterBar.tsx
+++ b/src/app/gallery/components/FilterBar.tsx
@@ -8,7 +8,10 @@ import {
   Plus,
   Square,
 } from "lucide-react";
+import { useEffect } from "react";
 import styles from "@/app/gallery/page.module.css";
+import { AutocompleteDropdown } from "@/components/AutocompleteDropdown";
+import { useSearchAutocomplete } from "@/hooks/useSearchAutocomplete";
 
 interface FilterBarProps {
   selectionMode: boolean;
@@ -21,6 +24,7 @@ interface FilterBarProps {
   columnCount: number;
   setColumnCount: (count: number) => void;
   onRefresh: () => void;
+  onSuppressSearch?: (suppress: boolean) => void;
 }
 
 export default function FilterBar({
@@ -34,7 +38,24 @@ export default function FilterBar({
   columnCount,
   setColumnCount,
   onRefresh,
+  onSuppressSearch,
 }: FilterBarProps) {
+  const {
+    suggestions,
+    selectedIndex,
+    isOpen,
+    inputRef,
+    handleKeyDown,
+    acceptSuggestion,
+    shouldSuppressSearch,
+  } = useSearchAutocomplete(searchQuery, setSearchQuery);
+
+  useEffect(() => {
+    if (onSuppressSearch) {
+      onSuppressSearch(shouldSuppressSearch);
+    }
+  }, [shouldSuppressSearch, onSuppressSearch]);
+
   // Parse field and direction from sortBy state
   const isRelevance = sortBy === "relevance";
   const currentField = isRelevance ? "relevance" : sortBy.split("-")[0];
@@ -82,14 +103,37 @@ export default function FilterBar({
 
       <div className={styles.separator} />
 
-      <input
-        type="text"
-        placeholder="Search (e.g. source:pixiv, min_favs:100, tag)..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-        onKeyDown={(e) => e.key === "Enter" && onRefresh()}
-        className={`${styles.input} ${styles.searchInput}`}
-      />
+      <div style={{ position: "relative", flex: 2, display: "flex" }}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Search (e.g. tag:landscape, extractor:pixiv)..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={(e) => {
+            handleKeyDown(e);
+            if (e.key === "Enter" && !isOpen) {
+              onRefresh();
+            }
+          }}
+          className={`${styles.input} ${styles.searchInput}`}
+          style={{ width: "100%" }}
+          aria-autocomplete="list"
+          aria-controls={isOpen ? "search-autocomplete-listbox" : undefined}
+          aria-expanded={isOpen}
+          role="combobox"
+          aria-activedescendant={
+            isOpen ? `suggestion-item-${selectedIndex}` : undefined
+          }
+        />
+        {isOpen && (
+          <AutocompleteDropdown
+            suggestions={suggestions}
+            selectedIndex={selectedIndex}
+            onSelect={acceptSuggestion}
+          />
+        )}
+      </div>
       <div className={styles.sortGroup}>
         <select
           value={currentField}

--- a/src/app/gallery/components/FilterBar.tsx
+++ b/src/app/gallery/components/FilterBar.tsx
@@ -4,6 +4,7 @@ import {
   ArrowDown,
   ArrowUp,
   CheckSquare,
+  Loader2,
   Minus,
   Plus,
   Square,
@@ -11,6 +12,7 @@ import {
 import { useEffect } from "react";
 import styles from "@/app/gallery/page.module.css";
 import { AutocompleteDropdown } from "@/components/AutocompleteDropdown";
+import dropdownStyles from "@/components/AutocompleteDropdown.module.css";
 import { useSearchAutocomplete } from "@/hooks/useSearchAutocomplete";
 
 interface FilterBarProps {
@@ -25,6 +27,7 @@ interface FilterBarProps {
   setColumnCount: (count: number) => void;
   onRefresh: () => void;
   onSuppressSearch?: (suppress: boolean) => void;
+  isSearching?: boolean;
 }
 
 export default function FilterBar({
@@ -39,6 +42,7 @@ export default function FilterBar({
   setColumnCount,
   onRefresh,
   onSuppressSearch,
+  isSearching = false,
 }: FilterBarProps) {
   const {
     suggestions,
@@ -117,7 +121,7 @@ export default function FilterBar({
             }
           }}
           className={`${styles.input} ${styles.searchInput}`}
-          style={{ width: "100%" }}
+          style={{ width: "100%", paddingRight: isSearching ? "36px" : "12px" }}
           aria-autocomplete="list"
           aria-controls={isOpen ? "search-autocomplete-listbox" : undefined}
           aria-expanded={isOpen}
@@ -126,6 +130,24 @@ export default function FilterBar({
             isOpen ? `suggestion-item-${selectedIndex}` : undefined
           }
         />
+        {isSearching && (
+          <div
+            style={{
+              position: "absolute",
+              right: "12px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "hsl(var(--muted-foreground))",
+              pointerEvents: "none",
+              zIndex: 10,
+            }}
+          >
+            <Loader2 className={dropdownStyles.spinner} size={18} />
+          </div>
+        )}
         {isOpen && (
           <AutocompleteDropdown
             suggestions={suggestions}

--- a/src/app/gallery/components/FilterBar.tsx
+++ b/src/app/gallery/components/FilterBar.tsx
@@ -14,6 +14,7 @@ import styles from "@/app/gallery/page.module.css";
 import { AutocompleteDropdown } from "@/components/AutocompleteDropdown";
 import dropdownStyles from "@/components/AutocompleteDropdown.module.css";
 import { useSearchAutocomplete } from "@/hooks/useSearchAutocomplete";
+import { saveFiltersToHistory } from "@/lib/utils/search-parser";
 
 interface FilterBarProps {
   selectionMode: boolean;
@@ -52,6 +53,7 @@ export default function FilterBar({
     handleKeyDown,
     acceptSuggestion,
     shouldSuppressSearch,
+    isLoading,
   } = useSearchAutocomplete(searchQuery, setSearchQuery);
 
   useEffect(() => {
@@ -117,6 +119,7 @@ export default function FilterBar({
           onKeyDown={(e) => {
             handleKeyDown(e);
             if (e.key === "Enter" && !isOpen) {
+              saveFiltersToHistory(searchQuery);
               onRefresh();
             }
           }}
@@ -153,6 +156,7 @@ export default function FilterBar({
             suggestions={suggestions}
             selectedIndex={selectedIndex}
             onSelect={acceptSuggestion}
+            isLoading={isLoading}
           />
         )}
       </div>

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -89,6 +89,8 @@ function GalleryPageContent({
   const [refetching, setRefetching] = useState(false);
   const [isAddToPlaylistOpen, setIsAddToPlaylistOpen] = useState(false);
 
+  const [suppressSearch, setSuppressSearch] = useState(false);
+
   const {
     items,
     searchQuery,
@@ -108,6 +110,7 @@ function GalleryPageContent({
     dataKey: "items",
     pageSize,
     playlistId,
+    suppressSearch,
   });
 
   const {
@@ -255,6 +258,7 @@ function GalleryPageContent({
         columnCount={columnCount}
         setColumnCount={setColumnCount}
         onRefresh={() => refresh()}
+        onSuppressSearch={setSuppressSearch}
       />
 
       <MasonryGrid

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -98,6 +98,7 @@ function GalleryPageContent({
     sortBy,
     setSortBy,
     isLoading,
+    isSearching,
     loadMore,
     refresh,
     hasMore,
@@ -259,6 +260,7 @@ function GalleryPageContent({
         setColumnCount={setColumnCount}
         onRefresh={() => refresh()}
         onSuppressSearch={setSuppressSearch}
+        isSearching={isSearching}
       />
 
       <MasonryGrid

--- a/src/app/timeline/components/FilterBar.tsx
+++ b/src/app/timeline/components/FilterBar.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { ArrowDown, ArrowUp } from "lucide-react";
+import { useEffect } from "react";
 import styles from "@/app/timeline/page.module.css";
+import { AutocompleteDropdown } from "@/components/AutocompleteDropdown";
+import { useSearchAutocomplete } from "@/hooks/useSearchAutocomplete";
 
 interface FilterBarProps {
   searchQuery: string;
   setSearchQuery: (query: string) => void;
   sortBy: string;
   setSortBy: (sort: string) => void;
+  onSuppressSearch?: (suppress: boolean) => void;
 }
 
 export default function FilterBar({
@@ -15,7 +19,24 @@ export default function FilterBar({
   setSearchQuery,
   sortBy,
   setSortBy,
+  onSuppressSearch,
 }: FilterBarProps) {
+  const {
+    suggestions,
+    selectedIndex,
+    isOpen,
+    inputRef,
+    handleKeyDown,
+    acceptSuggestion,
+    shouldSuppressSearch,
+  } = useSearchAutocomplete(searchQuery, setSearchQuery);
+
+  useEffect(() => {
+    if (onSuppressSearch) {
+      onSuppressSearch(shouldSuppressSearch);
+    }
+  }, [shouldSuppressSearch, onSuppressSearch]);
+
   // Parse field and direction from sortBy state
   const isRelevance = sortBy === "relevance";
   const currentField = isRelevance ? "relevance" : sortBy.split("-")[0];
@@ -41,13 +62,32 @@ export default function FilterBar({
 
   return (
     <div className={styles.filterBar}>
-      <input
-        type="text"
-        placeholder="Search timeline (e.g. source:twitter)..."
-        value={searchQuery}
-        onChange={(e) => setSearchQuery(e.target.value)}
-        className={`${styles.input} ${styles.searchInput}`}
-      />
+      <div style={{ position: "relative", flex: 2, display: "flex" }}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder="Search timeline (e.g. tag:landscape, extractor:twitter)..."
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          className={`${styles.input} ${styles.searchInput}`}
+          style={{ width: "100%" }}
+          aria-autocomplete="list"
+          aria-controls={isOpen ? "search-autocomplete-listbox" : undefined}
+          aria-expanded={isOpen}
+          role="combobox"
+          aria-activedescendant={
+            isOpen ? `suggestion-item-${selectedIndex}` : undefined
+          }
+        />
+        {isOpen && (
+          <AutocompleteDropdown
+            suggestions={suggestions}
+            selectedIndex={selectedIndex}
+            onSelect={acceptSuggestion}
+          />
+        )}
+      </div>
       <div className={styles.separator} />
       <div className={styles.sortGroup}>
         <select

--- a/src/app/timeline/components/FilterBar.tsx
+++ b/src/app/timeline/components/FilterBar.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { ArrowDown, ArrowUp } from "lucide-react";
+import { ArrowDown, ArrowUp, Loader2 } from "lucide-react";
 import { useEffect } from "react";
 import styles from "@/app/timeline/page.module.css";
 import { AutocompleteDropdown } from "@/components/AutocompleteDropdown";
+import dropdownStyles from "@/components/AutocompleteDropdown.module.css";
 import { useSearchAutocomplete } from "@/hooks/useSearchAutocomplete";
 
 interface FilterBarProps {
@@ -12,6 +13,7 @@ interface FilterBarProps {
   sortBy: string;
   setSortBy: (sort: string) => void;
   onSuppressSearch?: (suppress: boolean) => void;
+  isSearching?: boolean;
 }
 
 export default function FilterBar({
@@ -20,6 +22,7 @@ export default function FilterBar({
   sortBy,
   setSortBy,
   onSuppressSearch,
+  isSearching = false,
 }: FilterBarProps) {
   const {
     suggestions,
@@ -71,7 +74,7 @@ export default function FilterBar({
           onChange={(e) => setSearchQuery(e.target.value)}
           onKeyDown={handleKeyDown}
           className={`${styles.input} ${styles.searchInput}`}
-          style={{ width: "100%" }}
+          style={{ width: "100%", paddingRight: isSearching ? "36px" : "12px" }}
           aria-autocomplete="list"
           aria-controls={isOpen ? "search-autocomplete-listbox" : undefined}
           aria-expanded={isOpen}
@@ -80,6 +83,24 @@ export default function FilterBar({
             isOpen ? `suggestion-item-${selectedIndex}` : undefined
           }
         />
+        {isSearching && (
+          <div
+            style={{
+              position: "absolute",
+              right: "12px",
+              top: "50%",
+              transform: "translateY(-50%)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              color: "hsl(var(--muted-foreground))",
+              pointerEvents: "none",
+              zIndex: 10,
+            }}
+          >
+            <Loader2 className={dropdownStyles.spinner} size={18} />
+          </div>
+        )}
         {isOpen && (
           <AutocompleteDropdown
             suggestions={suggestions}

--- a/src/app/timeline/components/FilterBar.tsx
+++ b/src/app/timeline/components/FilterBar.tsx
@@ -6,6 +6,7 @@ import styles from "@/app/timeline/page.module.css";
 import { AutocompleteDropdown } from "@/components/AutocompleteDropdown";
 import dropdownStyles from "@/components/AutocompleteDropdown.module.css";
 import { useSearchAutocomplete } from "@/hooks/useSearchAutocomplete";
+import { saveFiltersToHistory } from "@/lib/utils/search-parser";
 
 interface FilterBarProps {
   searchQuery: string;
@@ -32,6 +33,7 @@ export default function FilterBar({
     handleKeyDown,
     acceptSuggestion,
     shouldSuppressSearch,
+    isLoading,
   } = useSearchAutocomplete(searchQuery, setSearchQuery);
 
   useEffect(() => {
@@ -72,7 +74,12 @@ export default function FilterBar({
           placeholder="Search timeline (e.g. tag:landscape, extractor:twitter)..."
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
+          onKeyDown={(e) => {
+            handleKeyDown(e);
+            if (e.key === "Enter" && !isOpen) {
+              saveFiltersToHistory(searchQuery);
+            }
+          }}
           className={`${styles.input} ${styles.searchInput}`}
           style={{ width: "100%", paddingRight: isSearching ? "36px" : "12px" }}
           aria-autocomplete="list"
@@ -106,6 +113,7 @@ export default function FilterBar({
             suggestions={suggestions}
             selectedIndex={selectedIndex}
             onSelect={acceptSuggestion}
+            isLoading={isLoading}
           />
         )}
       </div>

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import FilterBar from "@/app/timeline/components/FilterBar";
 import PostCard from "@/app/timeline/components/PostCard";
 import styles from "@/app/timeline/page.module.css";
@@ -89,6 +89,8 @@ function TimelinePageContent({
   condensePostText: boolean;
   condensePostLines: number;
 }) {
+  const [suppressSearch, setSuppressSearch] = useState(false);
+
   const {
     items: posts,
     searchQuery,
@@ -106,6 +108,7 @@ function TimelinePageContent({
     fetchPath: "/api/timeline",
     dataKey: "posts",
     pageSize,
+    suppressSearch,
   });
 
   const {
@@ -253,6 +256,7 @@ function TimelinePageContent({
         setSearchQuery={setSearchQuery}
         sortBy={sortBy}
         setSortBy={setSortBy}
+        onSuppressSearch={setSuppressSearch}
       />
 
       <div className={styles.feed}>

--- a/src/app/timeline/page-client.tsx
+++ b/src/app/timeline/page-client.tsx
@@ -98,6 +98,7 @@ function TimelinePageContent({
     sortBy,
     setSortBy,
     isLoading,
+    isSearching,
     loadMore,
     hasMore,
   } = usePaginatedData<TimelinePost>({
@@ -257,6 +258,7 @@ function TimelinePageContent({
         sortBy={sortBy}
         setSortBy={setSortBy}
         onSuppressSearch={setSuppressSearch}
+        isSearching={isSearching}
       />
 
       <div className={styles.feed}>

--- a/src/components/AutocompleteDropdown.module.css
+++ b/src/components/AutocompleteDropdown.module.css
@@ -75,3 +75,16 @@
     transform: translateY(0);
   }
 }
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/AutocompleteDropdown.module.css
+++ b/src/components/AutocompleteDropdown.module.css
@@ -1,0 +1,77 @@
+.autocompleteDropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin-top: 4px;
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  max-height: 320px;
+  overflow-y: auto;
+  animation: slideUp 0.15s ease-out;
+}
+
+.suggestionItem {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background 0.1s;
+}
+
+.suggestionItem[data-active="true"] {
+  background: hsl(var(--secondary));
+}
+
+.suggestionItem:hover {
+  background: hsl(var(--accent));
+}
+
+.suggestionIcon {
+  font-size: 1rem;
+  width: 1.25rem;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.suggestionTextContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+  flex-grow: 1;
+}
+
+.suggestionLabel {
+  font-weight: 500;
+  color: hsl(var(--foreground));
+}
+
+.suggestionDescription {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.75rem;
+}
+
+.suggestionCount {
+  color: hsl(var(--muted-foreground));
+  font-size: 0.75rem;
+  background: hsl(var(--secondary));
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  flex-shrink: 0;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}

--- a/src/components/AutocompleteDropdown.module.css
+++ b/src/components/AutocompleteDropdown.module.css
@@ -76,8 +76,40 @@
   }
 }
 
+.loadingContainer {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+}
+
+.loadingText {
+  color: hsl(var(--muted-foreground));
+}
+
+.topRightSpinnerContainer {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: hsl(var(--popover));
+  padding: 4px;
+  border-radius: 50%;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
 .spinner {
+  width: 1rem;
+  height: 1rem;
+  color: hsl(var(--primary));
   animation: spin 1s linear infinite;
+  flex-shrink: 0;
 }
 
 @keyframes spin {

--- a/src/components/AutocompleteDropdown.tsx
+++ b/src/components/AutocompleteDropdown.tsx
@@ -1,0 +1,88 @@
+import type React from "react";
+import { useEffect, useRef } from "react";
+import type { AutocompleteSuggestion } from "@/types/autocomplete";
+import styles from "./AutocompleteDropdown.module.css";
+
+interface AutocompleteDropdownProps {
+  suggestions: AutocompleteSuggestion[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}
+
+export const AutocompleteDropdown: React.FC<AutocompleteDropdownProps> = ({
+  suggestions,
+  selectedIndex,
+  onSelect,
+}) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll into view when selectedIndex changes
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const activeEl = containerRef.current.querySelector(
+      `[data-active="true"]`,
+    ) as HTMLElement;
+
+    if (activeEl) {
+      activeEl.scrollIntoView({
+        block: "nearest",
+        behavior: "auto",
+      });
+    }
+  }, [selectedIndex]);
+
+  if (suggestions.length === 0) return null;
+
+  return (
+    <div
+      ref={containerRef}
+      className={styles.autocompleteDropdown}
+      role="listbox"
+      id="search-autocomplete-listbox"
+      aria-label="Search suggestions"
+    >
+      {suggestions.map((suggestion, index) => {
+        const isActive = index === selectedIndex;
+        return (
+          <div
+            key={`${suggestion.type}-${suggestion.value}`}
+            className={styles.suggestionItem}
+            data-active={isActive}
+            onClick={() => onSelect(index)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onSelect(index);
+              }
+            }}
+            role="option"
+            aria-selected={isActive}
+            id={`suggestion-item-${index}`}
+            tabIndex={-1}
+          >
+            {suggestion.type === "column" && suggestion.icon && (
+              <span className={styles.suggestionIcon} aria-hidden="true">
+                {suggestion.icon}
+              </span>
+            )}
+
+            <div className={styles.suggestionTextContainer}>
+              <span className={styles.suggestionLabel}>{suggestion.label}</span>
+              {suggestion.description && (
+                <span className={styles.suggestionDescription}>
+                  {suggestion.description}
+                </span>
+              )}
+            </div>
+
+            {suggestion.count !== undefined && (
+              <span className={styles.suggestionCount}>
+                {suggestion.count} {suggestion.count === 1 ? "post" : "posts"}
+              </span>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/AutocompleteDropdown.tsx
+++ b/src/components/AutocompleteDropdown.tsx
@@ -7,12 +7,14 @@ interface AutocompleteDropdownProps {
   suggestions: AutocompleteSuggestion[];
   selectedIndex: number;
   onSelect: (index: number) => void;
+  isLoading?: boolean;
 }
 
 export const AutocompleteDropdown: React.FC<AutocompleteDropdownProps> = ({
   suggestions,
   selectedIndex,
   onSelect,
+  isLoading = false,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -31,7 +33,7 @@ export const AutocompleteDropdown: React.FC<AutocompleteDropdownProps> = ({
     }
   }, [selectedIndex]);
 
-  if (suggestions.length === 0) return null;
+  if (suggestions.length === 0 && !isLoading) return null;
 
   return (
     <div
@@ -41,6 +43,65 @@ export const AutocompleteDropdown: React.FC<AutocompleteDropdownProps> = ({
       id="search-autocomplete-listbox"
       aria-label="Search suggestions"
     >
+      {suggestions.length === 0 && isLoading && (
+        <div className={styles.loadingContainer}>
+          <svg
+            className={styles.spinner}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>Loading suggestions...</title>
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeDasharray="30 30"
+              opacity="0.25"
+            />
+            <path
+              d="M12 2C6.47715 2 2 6.47715 2 12C2 13.5997 2.37562 15.1116 3.0434 16.4523"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+          </svg>
+          <span className={styles.loadingText}>Loading suggestions...</span>
+        </div>
+      )}
+
+      {suggestions.length > 0 && isLoading && (
+        <div className={styles.topRightSpinnerContainer}>
+          <svg
+            className={styles.spinner}
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <title>Loading...</title>
+            <circle
+              cx="12"
+              cy="12"
+              r="10"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+              strokeDasharray="30 30"
+              opacity="0.25"
+            />
+            <path
+              d="M12 2C6.47715 2 2 6.47715 2 12C2 13.5997 2.37562 15.1116 3.0434 16.4523"
+              stroke="currentColor"
+              strokeWidth="3"
+              strokeLinecap="round"
+            />
+          </svg>
+        </div>
+      )}
+
       {suggestions.map((suggestion, index) => {
         const isActive = index === selectedIndex;
         return (

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -14,6 +14,7 @@ interface UsePaginatedDataOptions<T> {
   pageSize?: number;
   debounceMs?: number;
   playlistId?: number;
+  suppressSearch?: boolean;
 }
 
 export function usePaginatedData<T>({
@@ -26,6 +27,7 @@ export function usePaginatedData<T>({
   pageSize = 20,
   debounceMs = 1000,
   playlistId,
+  suppressSearch = false,
 }: UsePaginatedDataOptions<T>) {
   const [items, setItems] = useState<T[]>(initialItems);
   const [searchQuery, setSearchQuery] = useState(initialSearch);
@@ -117,8 +119,11 @@ export function usePaginatedData<T>({
       isFirstRender.current = false;
       return;
     }
+    if (suppressSearch) {
+      return;
+    }
     refresh();
-  }, [refresh]);
+  }, [refresh, suppressSearch]);
 
   return {
     items,

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -37,10 +37,18 @@ export function usePaginatedData<T>({
   );
   const [isLoading, setIsLoading] = useState(false);
 
-  // Keep a ref to nextCursor so loadMore can read the latest value
-  // without needing to be recreated on every cursor change.
+  // Keep refs to current values to avoid callback recreation
   const cursorRef = useRef(nextCursor);
   cursorRef.current = nextCursor;
+
+  const searchQueryRef = useRef(searchQuery);
+  searchQueryRef.current = searchQuery;
+
+  const sortByRef = useRef(sortBy);
+  sortByRef.current = sortBy;
+
+  const lastSearchedQueryRef = useRef(initialSearch);
+  const lastSearchedSortRef = useRef(initialSort);
 
   const debouncedSearch = useDebouncedValue(searchQuery, debounceMs);
   const debouncedSort = useDebouncedValue(sortBy, debounceMs);
@@ -48,10 +56,12 @@ export function usePaginatedData<T>({
   // Fetch a fresh page (cursor=null) and replace all items
   const refresh = useCallback(async () => {
     setIsLoading(true);
+    const queryToSearch = searchQueryRef.current;
+    const sortToSearch = sortByRef.current;
     try {
       const params = new URLSearchParams({
-        search: debouncedSearch,
-        sortBy: debouncedSort,
+        search: queryToSearch,
+        sortBy: sortToSearch,
         limit: String(pageSize),
       });
       if (playlistId) {
@@ -63,18 +73,13 @@ export function usePaginatedData<T>({
         const data = await res.json();
         setItems(data[dataKey]);
         setNextCursor(data.nextCursor);
+        lastSearchedQueryRef.current = queryToSearch;
+        lastSearchedSortRef.current = sortToSearch;
       }
     } finally {
       setIsLoading(false);
     }
-  }, [
-    debouncedSearch,
-    debouncedSort,
-    fetchPath,
-    dataKey,
-    pageSize,
-    playlistId,
-  ]);
+  }, [fetchPath, dataKey, pageSize, playlistId]);
 
   // Append the next page using the current cursor
   const loadMore = useCallback(async () => {
@@ -84,8 +89,8 @@ export function usePaginatedData<T>({
     setIsLoading(true);
     try {
       const params = new URLSearchParams({
-        search: debouncedSearch,
-        sortBy: debouncedSort,
+        search: lastSearchedQueryRef.current,
+        sortBy: lastSearchedSortRef.current,
         limit: String(pageSize),
         cursor,
       });
@@ -102,18 +107,12 @@ export function usePaginatedData<T>({
     } finally {
       setIsLoading(false);
     }
-  }, [
-    debouncedSearch,
-    debouncedSort,
-    fetchPath,
-    dataKey,
-    pageSize,
-    playlistId,
-  ]);
+  }, [fetchPath, dataKey, pageSize, playlistId]);
 
   // Reset and re-fetch when search/sort changes
   const isFirstRender = useRef(true);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: run search on debounced search/sort changes or suppress changes
   useEffect(() => {
     if (isFirstRender.current) {
       isFirstRender.current = false;
@@ -122,8 +121,15 @@ export function usePaginatedData<T>({
     if (suppressSearch) {
       return;
     }
+    // Only query if the query or sort has actually changed from what was last loaded
+    if (
+      searchQueryRef.current === lastSearchedQueryRef.current &&
+      sortByRef.current === lastSearchedSortRef.current
+    ) {
+      return;
+    }
     refresh();
-  }, [refresh, suppressSearch]);
+  }, [refresh, debouncedSearch, debouncedSort, suppressSearch]);
 
   const isSearching = isLoading || searchQuery !== debouncedSearch;
 

--- a/src/hooks/usePaginatedData.ts
+++ b/src/hooks/usePaginatedData.ts
@@ -125,6 +125,8 @@ export function usePaginatedData<T>({
     refresh();
   }, [refresh, suppressSearch]);
 
+  const isSearching = isLoading || searchQuery !== debouncedSearch;
+
   return {
     items,
     setItems,
@@ -135,6 +137,7 @@ export function usePaginatedData<T>({
     nextCursor,
     setNextCursor,
     isLoading,
+    isSearching,
     loadMore,
     refresh,
     hasMore: nextCursor !== null,

--- a/src/hooks/useSearchAutocomplete.ts
+++ b/src/hooks/useSearchAutocomplete.ts
@@ -1,0 +1,228 @@
+import { useEffect, useRef, useState } from "react";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import { SEARCH_COLUMNS } from "@/lib/utils/search-parser";
+import type {
+  AutocompleteResponse,
+  AutocompleteSuggestion,
+} from "@/types/autocomplete";
+
+export function useSearchAutocomplete(
+  value: string,
+  onChange: (newValue: string) => void,
+) {
+  const [suggestions, setSuggestions] = useState<AutocompleteSuggestion[]>([]);
+  const [selectedIndex, setSelectedIndex] = useState<number>(0);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const [phase, setPhase] = useState<"column" | "value">("column");
+  const [activeColumn, setActiveColumn] = useState<string | null>(null);
+
+  // Track raw value query for value phase, which we'll debounce
+  const [valueQuery, setValueQuery] = useState<string>("");
+  const debouncedValueQuery = useDebouncedValue(valueQuery, 200);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Parse word at current cursor position
+  const getWordAtCursor = (text: string, cursorOffset: number) => {
+    const beforeCursor = text.slice(0, cursorOffset);
+    const afterCursor = text.slice(cursorOffset);
+
+    const lastSpaceBefore = beforeCursor.lastIndexOf(" ");
+    const start = lastSpaceBefore === -1 ? 0 : lastSpaceBefore + 1;
+
+    const firstSpaceAfter = afterCursor.indexOf(" ");
+    const end =
+      firstSpaceAfter === -1 ? text.length : cursorOffset + firstSpaceAfter;
+
+    const word = text.slice(start, end);
+    return { word, start, end };
+  };
+
+  const recalculate = () => {
+    if (!inputRef.current) return;
+    const input = inputRef.current;
+    const text = input.value;
+    const cursorOffset = input.selectionStart ?? 0;
+
+    const { word } = getWordAtCursor(text, cursorOffset);
+
+    // If word has a colon, we are in 'value' phase
+    const colonIndex = word.indexOf(":");
+    if (colonIndex !== -1) {
+      const colPrefix = word.slice(0, colonIndex).toLowerCase();
+      const valQuery = word.slice(colonIndex + 1);
+
+      // Check if it's a valid column alias
+      const isValidColumn = SEARCH_COLUMNS.some(
+        (c) => c.alias.toLowerCase() === `${colPrefix}:`,
+      );
+
+      if (isValidColumn) {
+        setPhase("value");
+        setActiveColumn(colPrefix);
+        setValueQuery(valQuery);
+        setIsOpen(true);
+        return;
+      }
+    }
+
+    // Otherwise, we are in 'column' phase
+    setPhase("column");
+    setActiveColumn(null);
+    setValueQuery("");
+
+    // Show column suggestions matching current typed word (if any)
+    if (word && !word.includes(":")) {
+      const filtered = SEARCH_COLUMNS.filter((c) =>
+        c.alias.toLowerCase().startsWith(word.toLowerCase()),
+      ).map((c) => ({
+        value: c.alias,
+        label: c.alias,
+        description: c.description,
+        icon: c.icon,
+        type: "column" as const,
+      }));
+
+      if (filtered.length > 0) {
+        setSuggestions(filtered);
+        setIsOpen(true);
+        setSelectedIndex(0);
+        return;
+      }
+    }
+
+    // Default to closed if no matching columns/values
+    setSuggestions([]);
+    setIsOpen(false);
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: recalculate on value changes
+  useEffect(() => {
+    recalculate();
+  }, [value]);
+
+  // Fetch value suggestions when activeColumn or debouncedValueQuery changes
+  useEffect(() => {
+    if (phase !== "value" || !activeColumn) return;
+
+    const col = activeColumn;
+    let active = true;
+
+    async function fetchValueSuggestions() {
+      try {
+        const res = await fetch(
+          `/api/autocomplete?column=${encodeURIComponent(
+            col,
+          )}&q=${encodeURIComponent(debouncedValueQuery)}`,
+        );
+        if (!res.ok)
+          throw new Error("Failed to fetch autocomplete suggestions");
+        const data: AutocompleteResponse = await res.json();
+
+        if (active) {
+          setSuggestions(data.suggestions);
+          setSelectedIndex(0);
+          setIsOpen(data.suggestions.length > 0);
+        }
+      } catch (err) {
+        console.error(err);
+        if (active) {
+          setSuggestions([]);
+          setIsOpen(false);
+        }
+      }
+    }
+
+    fetchValueSuggestions();
+
+    return () => {
+      active = false;
+    };
+  }, [phase, activeColumn, debouncedValueQuery]);
+
+  const acceptSuggestion = (index: number) => {
+    const suggestion = suggestions[index];
+    if (!suggestion || !inputRef.current) return;
+
+    const input = inputRef.current;
+    const text = input.value;
+    const cursorOffset = input.selectionStart ?? 0;
+    const { start, end } = getWordAtCursor(text, cursorOffset);
+
+    let replacement = "";
+    let newCursorPos = 0;
+
+    if (suggestion.type === "column") {
+      replacement = suggestion.value; // e.g., "tag:"
+      newCursorPos = start + replacement.length;
+    } else {
+      // Value suggestion: preserve the column prefix
+      const currentWord = text.slice(start, end);
+      const colonIdx = currentWord.indexOf(":");
+      const columnPrefix =
+        colonIdx !== -1 ? currentWord.slice(0, colonIdx + 1) : "";
+
+      replacement = `${columnPrefix}${suggestion.value} `;
+      newCursorPos = start + replacement.length;
+    }
+
+    const newText = text.slice(0, start) + replacement + text.slice(end);
+    onChange(newText);
+
+    // Reposition cursor on next tick
+    setTimeout(() => {
+      if (inputRef.current) {
+        inputRef.current.focus();
+        inputRef.current.setSelectionRange(newCursorPos, newCursorPos);
+        recalculate();
+      }
+    }, 0);
+
+    setIsOpen(false);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (!isOpen || suggestions.length === 0) return;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        setSelectedIndex((prev) => (prev + 1) % suggestions.length);
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        setSelectedIndex(
+          (prev) => (prev - 1 + suggestions.length) % suggestions.length,
+        );
+        break;
+      case "Enter":
+      case "Tab":
+        e.preventDefault();
+        acceptSuggestion(selectedIndex);
+        break;
+      case "Escape":
+        e.preventDefault();
+        setIsOpen(false);
+        break;
+      case " ":
+        if (phase === "column") {
+          // Close dropdown on space key press in column phase to allow normal typing
+          setIsOpen(false);
+        }
+        break;
+    }
+  };
+
+  return {
+    suggestions,
+    selectedIndex,
+    isOpen,
+    phase,
+    inputRef,
+    handleKeyDown,
+    acceptSuggestion,
+    shouldSuppressSearch: isOpen,
+    recalculate,
+    setIsOpen,
+  };
+}

--- a/src/hooks/useSearchAutocomplete.ts
+++ b/src/hooks/useSearchAutocomplete.ts
@@ -1,10 +1,29 @@
 import { useEffect, useRef, useState } from "react";
 import { useDebouncedValue } from "@/hooks/useDebouncedValue";
-import { SEARCH_COLUMNS } from "@/lib/utils/search-parser";
+import {
+  SEARCH_COLUMNS,
+  saveFiltersToHistory,
+} from "@/lib/utils/search-parser";
 import type {
   AutocompleteResponse,
   AutocompleteSuggestion,
 } from "@/types/autocomplete";
+
+// Parse word at current cursor position
+const getWordAtCursor = (text: string, cursorOffset: number) => {
+  const beforeCursor = text.slice(0, cursorOffset);
+  const afterCursor = text.slice(cursorOffset);
+
+  const lastSpaceBefore = beforeCursor.lastIndexOf(" ");
+  const start = lastSpaceBefore === -1 ? 0 : lastSpaceBefore + 1;
+
+  const firstSpaceAfter = afterCursor.indexOf(" ");
+  const end =
+    firstSpaceAfter === -1 ? text.length : cursorOffset + firstSpaceAfter;
+
+  const word = text.slice(start, end);
+  return { word, start, end };
+};
 
 export function useSearchAutocomplete(
   value: string,
@@ -15,28 +34,13 @@ export function useSearchAutocomplete(
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const [phase, setPhase] = useState<"column" | "value">("column");
   const [activeColumn, setActiveColumn] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
 
   // Track raw value query for value phase, which we'll debounce
   const [valueQuery, setValueQuery] = useState<string>("");
   const debouncedValueQuery = useDebouncedValue(valueQuery, 200);
 
   const inputRef = useRef<HTMLInputElement>(null);
-
-  // Parse word at current cursor position
-  const getWordAtCursor = (text: string, cursorOffset: number) => {
-    const beforeCursor = text.slice(0, cursorOffset);
-    const afterCursor = text.slice(cursorOffset);
-
-    const lastSpaceBefore = beforeCursor.lastIndexOf(" ");
-    const start = lastSpaceBefore === -1 ? 0 : lastSpaceBefore + 1;
-
-    const firstSpaceAfter = afterCursor.indexOf(" ");
-    const end =
-      firstSpaceAfter === -1 ? text.length : cursorOffset + firstSpaceAfter;
-
-    const word = text.slice(start, end);
-    return { word, start, end };
-  };
 
   const recalculate = () => {
     if (!inputRef.current) return;
@@ -58,6 +62,9 @@ export function useSearchAutocomplete(
       );
 
       if (isValidColumn) {
+        if (phase !== "value" || valQuery !== valueQuery) {
+          setIsLoading(true);
+        }
         setPhase("value");
         setActiveColumn(colPrefix);
         setValueQuery(valQuery);
@@ -68,6 +75,7 @@ export function useSearchAutocomplete(
 
     // Otherwise, we are in 'column' phase
     setPhase("column");
+    setIsLoading(false);
     setActiveColumn(null);
     setValueQuery("");
 
@@ -109,26 +117,92 @@ export function useSearchAutocomplete(
     let active = true;
 
     async function fetchValueSuggestions() {
+      setIsLoading(true);
       try {
+        let context = "";
+        if (inputRef.current) {
+          const text = inputRef.current.value;
+          const cursorOffset = inputRef.current.selectionStart ?? 0;
+          const { start, end } = getWordAtCursor(text, cursorOffset);
+          const textWithoutWord = text.slice(0, start) + text.slice(end);
+          context = textWithoutWord.trim();
+        }
+
+        const contextParam = context
+          ? `&context=${encodeURIComponent(context)}`
+          : "";
         const res = await fetch(
           `/api/autocomplete?column=${encodeURIComponent(
             col,
-          )}&q=${encodeURIComponent(debouncedValueQuery)}`,
+          )}&q=${encodeURIComponent(debouncedValueQuery)}${contextParam}`,
         );
         if (!res.ok)
           throw new Error("Failed to fetch autocomplete suggestions");
         const data: AutocompleteResponse = await res.json();
 
         if (active) {
-          setSuggestions(data.suggestions);
+          // Load local history matching the column prefix and query
+          let historySuggestions: AutocompleteSuggestion[] = [];
+          if (typeof window !== "undefined") {
+            try {
+              const historyJson = localStorage.getItem(
+                "webgallery_search_history",
+              );
+              const history: string[] = historyJson
+                ? JSON.parse(historyJson)
+                : [];
+              const prefix = `${col}:`;
+
+              historySuggestions = history
+                .filter(
+                  (x) =>
+                    x.toLowerCase().startsWith(prefix.toLowerCase()) &&
+                    x.toLowerCase() !== prefix.toLowerCase(),
+                )
+                .map((x) => {
+                  const val = x.slice(prefix.length);
+                  return {
+                    value: val,
+                    label: val,
+                    description: "recent search",
+                    icon: "🕒",
+                    type: "value" as const,
+                  };
+                })
+                .filter((s) =>
+                  s.value
+                    .toLowerCase()
+                    .startsWith(debouncedValueQuery.toLowerCase()),
+                );
+            } catch (err) {
+              console.error("Failed to load local history:", err);
+            }
+          }
+
+          // Merge local history with global recommendations, preventing duplicates
+          const combined = [
+            ...historySuggestions,
+            ...data.suggestions.filter(
+              (ns) =>
+                !historySuggestions.some(
+                  (hs) => hs.value.toLowerCase() === ns.value.toLowerCase(),
+                ),
+            ),
+          ];
+
+          setSuggestions(combined);
           setSelectedIndex(0);
-          setIsOpen(data.suggestions.length > 0);
+          setIsOpen(combined.length > 0);
         }
       } catch (err) {
         console.error(err);
         if (active) {
           setSuggestions([]);
           setIsOpen(false);
+        }
+      } finally {
+        if (active) {
+          setIsLoading(false);
         }
       }
     }
@@ -169,6 +243,11 @@ export function useSearchAutocomplete(
     const newText = text.slice(0, start) + replacement + text.slice(end);
     onChange(newText);
 
+    // Save to history when a value suggestion is committed
+    if (suggestion.type === "value") {
+      saveFiltersToHistory(newText);
+    }
+
     // Reposition cursor on next tick
     setTimeout(() => {
       if (inputRef.current) {
@@ -178,7 +257,9 @@ export function useSearchAutocomplete(
       }
     }, 0);
 
-    setIsOpen(false);
+    if (suggestion.type === "value") {
+      setIsOpen(false);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
@@ -224,5 +305,6 @@ export function useSearchAutocomplete(
     shouldSuppressSearch: isOpen,
     recalculate,
     setIsOpen,
+    isLoading,
   };
 }

--- a/src/lib/db/repositories/autocomplete.ts
+++ b/src/lib/db/repositories/autocomplete.ts
@@ -1,0 +1,198 @@
+import { and, eq, isNull, like, sql } from "drizzle-orm";
+import { db } from "@/lib/db";
+import {
+  pixivUsers,
+  posts,
+  postTags,
+  sources,
+  tags,
+  twitterUsers,
+} from "@/lib/db/schema";
+import type { AutocompleteSuggestion } from "@/types/autocomplete";
+
+export async function autocompleteTag(
+  prefix: string,
+  limit: number = 8,
+): Promise<AutocompleteSuggestion[]> {
+  const results = await db
+    .select({
+      name: tags.name,
+      count: sql<number>`count(${postTags.postId})`.mapWith(Number),
+    })
+    .from(tags)
+    .leftJoin(postTags, eq(tags.id, postTags.tagId))
+    .where(like(tags.name, `${prefix}%`))
+    .groupBy(tags.name)
+    .orderBy(sql`count(${postTags.postId}) DESC`)
+    .limit(limit);
+
+  return results.map((r) => ({
+    value: r.name,
+    label: r.name,
+    count: r.count,
+    type: "value" as const,
+  }));
+}
+
+export async function autocompleteUser(
+  prefix: string,
+  limit: number = 8,
+): Promise<AutocompleteSuggestion[]> {
+  const [twitterRes, pixivRes] = await Promise.all([
+    db
+      .select({
+        name: twitterUsers.name,
+        handle: twitterUsers.nick,
+      })
+      .from(twitterUsers)
+      .where(like(twitterUsers.name, `${prefix}%`))
+      .limit(limit),
+    db
+      .select({
+        name: pixivUsers.name,
+        account: pixivUsers.account,
+      })
+      .from(pixivUsers)
+      .where(like(pixivUsers.name, `${prefix}%`))
+      .limit(limit),
+  ]);
+
+  const merged = [
+    ...twitterRes.map((u) => ({
+      value: u.name || "",
+      label: u.name || "",
+      description: u.handle ? `@${u.handle}` : undefined,
+      type: "value" as const,
+    })),
+    ...pixivRes.map((u) => ({
+      value: u.name || "",
+      label: u.name || "",
+      description: u.account ? `@${u.account}` : undefined,
+      type: "value" as const,
+    })),
+  ].filter((u) => u.value !== "");
+
+  // Remove duplicates by value
+  const unique = Array.from(
+    new Map(merged.map((item) => [item.value, item])).values(),
+  );
+  return unique.slice(0, limit);
+}
+
+export async function autocompleteHandle(
+  prefix: string,
+  limit: number = 8,
+): Promise<AutocompleteSuggestion[]> {
+  // Handles usually typed with or without '@' - strip '@' if present
+  const cleanPrefix = prefix.startsWith("@") ? prefix.slice(1) : prefix;
+
+  const [twitterRes, pixivRes] = await Promise.all([
+    db
+      .select({
+        name: twitterUsers.name,
+        handle: twitterUsers.nick,
+      })
+      .from(twitterUsers)
+      .where(like(twitterUsers.nick, `${cleanPrefix}%`))
+      .limit(limit),
+    db
+      .select({
+        name: pixivUsers.name,
+        account: pixivUsers.account,
+      })
+      .from(pixivUsers)
+      .where(like(pixivUsers.account, `${cleanPrefix}%`))
+      .limit(limit),
+  ]);
+
+  const merged = [
+    ...twitterRes.map((u) => ({
+      value: u.handle || "",
+      label: `@${u.handle}`,
+      description: u.name || undefined,
+      type: "value" as const,
+    })),
+    ...pixivRes.map((u) => ({
+      value: u.account || "",
+      label: `@${u.account}`,
+      description: u.name || undefined,
+      type: "value" as const,
+    })),
+  ].filter((u) => u.value !== "");
+
+  const unique = Array.from(
+    new Map(merged.map((item) => [item.value, item])).values(),
+  );
+  return unique.slice(0, limit);
+}
+
+export async function autocompleteSourceName(
+  prefix: string,
+  limit: number = 8,
+): Promise<AutocompleteSuggestion[]> {
+  const results = await db
+    .select({
+      name: sources.name,
+    })
+    .from(sources)
+    .where(and(like(sources.name, `${prefix}%`), isNull(sources.deletedAt)))
+    .limit(limit);
+
+  const filtered = results.filter((r) => r.name !== null && r.name !== "");
+
+  return filtered.map((r) => ({
+    value: r.name as string,
+    label: r.name as string,
+    type: "value" as const,
+  }));
+}
+
+export async function autocompleteTitle(
+  prefix: string,
+  limit: number = 8,
+): Promise<AutocompleteSuggestion[]> {
+  const results = await db
+    .select({
+      title: posts.title,
+    })
+    .from(posts)
+    .where(and(like(posts.title, `${prefix}%`), isNull(posts.deletedAt)))
+    .limit(limit);
+
+  const filtered = results.filter((r) => r.title !== null && r.title !== "");
+  const unique = Array.from(new Set(filtered.map((r) => r.title as string)));
+
+  return unique.slice(0, limit).map((t) => ({
+    value: t,
+    label: t,
+    type: "value" as const,
+  }));
+}
+
+export async function autocompleteContent(
+  prefix: string,
+  limit: number = 8,
+): Promise<AutocompleteSuggestion[]> {
+  const results = await db
+    .select({
+      content: posts.content,
+    })
+    .from(posts)
+    .where(and(like(posts.content, `${prefix}%`), isNull(posts.deletedAt)))
+    .limit(limit);
+
+  const filtered = results.filter(
+    (r) => r.content !== null && r.content !== "",
+  );
+  const unique = Array.from(new Set(filtered.map((r) => r.content as string)));
+
+  return unique.slice(0, limit).map((c) => {
+    // Truncate long content for list item display
+    const label = c.length > 50 ? `${c.slice(0, 50)}...` : c;
+    return {
+      value: c,
+      label,
+      type: "value" as const,
+    };
+  });
+}

--- a/src/lib/db/repositories/autocomplete.ts
+++ b/src/lib/db/repositories/autocomplete.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, like, sql } from "drizzle-orm";
+import { and, eq, isNull, like, notInArray, type SQL, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import {
   pixivUsers,
@@ -8,20 +8,83 @@ import {
   tags,
   twitterUsers,
 } from "@/lib/db/schema";
+import { parseSearchQuery } from "@/lib/utils/search-parser";
 import type { AutocompleteSuggestion } from "@/types/autocomplete";
 
 export async function autocompleteTag(
   prefix: string,
   limit: number = 8,
+  context?: string,
 ): Promise<AutocompleteSuggestion[]> {
-  const results = await db
+  const existingTags = context
+    ? Array.from(context.matchAll(/\btag:(\S+)/gi)).map((m) => m[1])
+    : [];
+
+  const whereConditions: SQL[] = [like(tags.name, `${prefix}%`)];
+  if (existingTags.length > 0) {
+    const lowerTags = existingTags.map((t) => t.toLowerCase());
+    whereConditions.push(notInArray(sql`lower(${tags.name})`, lowerTags));
+  }
+
+  // If there's a context, let's find posts matching it
+  // biome-ignore lint/suspicious/noExplicitAny: Drizzle dynamic query typing requires any for reassignment
+  let postsFilterSubquery: any = null;
+  if (context) {
+    const { cleanQuery, sourceFilter } = parseSearchQuery(context);
+    const searchLower = cleanQuery.trim().toLowerCase();
+
+    if (searchLower || sourceFilter) {
+      const postWhereConditions: SQL[] = [isNull(posts.deletedAt)];
+      if (sourceFilter) {
+        postWhereConditions.push(eq(posts.extractorType, sourceFilter));
+      }
+
+      let q = db
+        .select({
+          id: posts.id,
+        })
+        .from(posts)
+        .$dynamic();
+
+      if (searchLower) {
+        const ftsSub = db
+          .select({
+            search_id: sql<number>`rowid`.as("search_id"),
+          })
+          .from(sql`posts_fts`)
+          .where(sql`posts_fts MATCH ${searchLower}`)
+          .as("fts_sub");
+
+        q = q.innerJoin(ftsSub, eq(posts.id, ftsSub.search_id));
+      }
+
+      postsFilterSubquery = q
+        .where(and(...postWhereConditions))
+        .as("posts_filter_subquery");
+    }
+  }
+
+  let query = db
     .select({
       name: tags.name,
       count: sql<number>`count(${postTags.postId})`.mapWith(Number),
     })
     .from(tags)
-    .leftJoin(postTags, eq(tags.id, postTags.tagId))
-    .where(like(tags.name, `${prefix}%`))
+    .$dynamic();
+
+  if (postsFilterSubquery) {
+    query = query
+      .innerJoin(postTags, eq(tags.id, postTags.tagId))
+      .innerJoin(
+        postsFilterSubquery,
+        eq(postTags.postId, postsFilterSubquery.id),
+      );
+  } else {
+    query = query.leftJoin(postTags, eq(tags.id, postTags.tagId));
+  }
+
+  const results = await query
+    .where(and(...whereConditions))
     .groupBy(tags.name)
     .orderBy(sql`count(${postTags.postId}) DESC`)
     .limit(limit);

--- a/src/lib/utils/search-parser.ts
+++ b/src/lib/utils/search-parser.ts
@@ -3,29 +3,90 @@ export interface ParsedSearchQuery {
   sourceFilter: string | null;
 }
 
+export interface SearchFilterColumn {
+  alias: string;
+  name: string;
+  icon: string;
+  description: string;
+  type: "dynamic" | "static";
+}
+
+export const SEARCH_COLUMNS: SearchFilterColumn[] = [
+  {
+    alias: "tag:",
+    name: "Tag",
+    icon: "🏷️",
+    description: "Filter by tag name",
+    type: "dynamic",
+  },
+  {
+    alias: "user:",
+    name: "User",
+    icon: "👤",
+    description: "Filter by username",
+    type: "dynamic",
+  },
+  {
+    alias: "handle:",
+    name: "Handle",
+    icon: "@",
+    description: "Filter by user handle",
+    type: "dynamic",
+  },
+  {
+    alias: "title:",
+    name: "Title",
+    icon: "📝",
+    description: "Filter by post title",
+    type: "dynamic",
+  },
+  {
+    alias: "content:",
+    name: "Content",
+    icon: "📄",
+    description: "Filter by post content",
+    type: "dynamic",
+  },
+  {
+    alias: "source:",
+    name: "Source",
+    icon: "🔗",
+    description: "Filter by extractor type",
+    type: "static",
+  },
+  {
+    alias: "extractor:",
+    name: "Extractor",
+    icon: "⚙️",
+    description: "Filter by extractor type",
+    type: "static",
+  },
+];
+
+export const ftsColumnAliases: Record<string, string> = {
+  tag: "tag_names",
+  tag_names: "tag_names",
+  user: "user_name",
+  user_name: "user_name",
+  handle: "user_handle",
+  user_handle: "user_handle",
+  title: "title",
+  content: "content",
+  source_name: "source_name",
+};
+
 export function parseSearchQuery(search: string = ""): ParsedSearchQuery {
   let cleanQuery = search;
 
   let sourceFilter: string | null = null;
-  const sourceMatch = cleanQuery.match(/source:([a-zA-Z0-9_-]+)/i);
+  // Match either "source:xyz" or "extractor:xyz"
+  const sourceMatch = cleanQuery.match(
+    /(?:source|extractor):([a-zA-Z0-9_-]+)/i,
+  );
   if (sourceMatch) {
     sourceFilter = sourceMatch[1].toLowerCase();
     cleanQuery = cleanQuery.replace(sourceMatch[0], "").trim();
   }
-
-  // Define friendly aliases mapping to actual FTS5 virtual table column names
-  const ftsColumnAliases: Record<string, string> = {
-    tag: "tag_names",
-    tag_names: "tag_names",
-    user: "user_name",
-    user_name: "user_name",
-    handle: "user_handle",
-    user_handle: "user_handle",
-    title: "title",
-    content: "content",
-    source_name: "source_name",
-    // Add future extractor mappings here
-  };
 
   const validFtsColumns = new Set(Object.values(ftsColumnAliases));
 

--- a/src/lib/utils/search-parser.ts
+++ b/src/lib/utils/search-parser.ts
@@ -76,7 +76,10 @@ export const ftsColumnAliases: Record<string, string> = {
 };
 
 export function parseSearchQuery(search: string = ""): ParsedSearchQuery {
-  let cleanQuery = search;
+  // Strip trailing incomplete column prefixes like "tag:", "user:", "source:", etc. at the end of the query
+  const trailingPrefixRegex =
+    /\b(?:tag|user|handle|title|content|source|extractor):\s*$/i;
+  let cleanQuery = search.replace(trailingPrefixRegex, "").trim();
 
   let sourceFilter: string | null = null;
   // Match either "source:xyz" or "extractor:xyz"
@@ -114,4 +117,29 @@ export function parseSearchQuery(search: string = ""): ParsedSearchQuery {
   });
 
   return { cleanQuery, sourceFilter };
+}
+
+export function saveFiltersToHistory(query: string) {
+  if (typeof window === "undefined") return;
+  const filterMatches = query.match(/\b([a-zA-Z0-9_]+):([a-zA-Z0-9_-]+)/g);
+  if (!filterMatches) return;
+
+  try {
+    const historyJson = localStorage.getItem("webgallery_search_history");
+    let history: string[] = historyJson ? JSON.parse(historyJson) : [];
+
+    for (const filter of filterMatches) {
+      const lowerFilter = filter.toLowerCase();
+      // Remove duplicate if it already exists
+      history = history.filter((x) => x.toLowerCase() !== lowerFilter);
+      // Prepend to top
+      history.unshift(filter);
+    }
+
+    // Cap at 30 items
+    history = history.slice(0, 30);
+    localStorage.setItem("webgallery_search_history", JSON.stringify(history));
+  } catch (err) {
+    console.error("Failed to save search history:", err);
+  }
 }

--- a/src/types/autocomplete.ts
+++ b/src/types/autocomplete.ts
@@ -1,0 +1,12 @@
+export interface AutocompleteSuggestion {
+  value: string; // The text to insert (e.g., "landscape" or "tag:")
+  label: string; // Display text
+  description?: string; // Secondary text (e.g., "Filter by tag name")
+  count?: number; // Post count for value suggestions
+  icon?: string; // Emoji icon for column suggestions
+  type: "column" | "value";
+}
+
+export interface AutocompleteResponse {
+  suggestions: AutocompleteSuggestion[];
+}

--- a/tests/autocomplete.spec.ts
+++ b/tests/autocomplete.spec.ts
@@ -95,4 +95,94 @@ test.describe("Search Autocomplete E2E", () => {
     await page.keyboard.press("Escape");
     await expect(dropdown).not.toBeVisible();
   });
+
+  test("should show context-aware suggestions (co-occurring tags)", async ({
+    page,
+  }) => {
+    await page.goto("/gallery");
+    await expect(page.getByTestId("loading-skeleton")).toBeHidden();
+
+    // Check for grid items
+    const mediaItems = page.locator(
+      'img[class*="media"], video[class*="media"]',
+    );
+    const itemsCount = await mediaItems.count();
+    if (itemsCount === 0) {
+      test.skip(
+        true,
+        "No gallery items found - skipping context-aware suggestion test",
+      );
+      return;
+    }
+
+    let tag1 = "";
+    let tag2 = "";
+
+    // Iterate through the first few items to find one with at least 2 tags
+    const maxToInspect = Math.min(itemsCount, 5);
+    for (let i = 0; i < maxToInspect; i++) {
+      await mediaItems.nth(i).click();
+
+      const lightbox = page.locator('div[class*="overlay"]');
+      await expect(lightbox).toBeVisible();
+
+      // Find the tag chips in the lightbox
+      const tagChips = page.locator('span[class*="tagChip"]');
+      const chipsCount = await tagChips.count();
+
+      if (chipsCount >= 2) {
+        const text1 = await tagChips.nth(0).textContent();
+        const text2 = await tagChips.nth(1).textContent();
+
+        if (text1 && text2) {
+          tag1 = text1.trim().replace(/^#/, "");
+          tag2 = text2.trim().replace(/^#/, "");
+
+          // Make sure the tag names don't contain spaces to keep autocomplete simple
+          if (tag1 && tag2 && !tag1.includes(" ") && !tag2.includes(" ")) {
+            await page.keyboard.press("Escape");
+            await expect(lightbox).not.toBeVisible();
+            break;
+          }
+        }
+      }
+
+      // Close lightbox and try next item
+      await page.keyboard.press("Escape");
+      await expect(lightbox).not.toBeVisible();
+    }
+
+    if (!tag1 || !tag2) {
+      test.skip(
+        true,
+        "No posts with 2+ valid tags found - skipping context-aware suggestion test",
+      );
+      return;
+    }
+
+    const searchInput = page.getByPlaceholder(/Search \(e\.g\..*\)/).first();
+    await searchInput.focus();
+
+    // Type the first filter
+    await searchInput.pressSequentially(`tag:${tag1} `, { delay: 50 });
+    await expect(searchInput).toHaveValue(`tag:${tag1} `);
+
+    // Type the next filter prefix (first few characters of tag2)
+    const tag2Prefix = tag2.slice(0, Math.max(1, Math.min(3, tag2.length)));
+    await searchInput.pressSequentially(`tag:${tag2Prefix}`, { delay: 50 });
+    await expect(searchInput).toHaveValue(`tag:${tag1} tag:${tag2Prefix}`);
+
+    const dropdown = page.locator("#search-autocomplete-listbox");
+    await expect(dropdown).toBeVisible();
+
+    // The first option or suggestions list should update to contain tag2
+    const firstOption = page.locator("#suggestion-item-0");
+    await expect(firstOption).toContainText(tag2);
+
+    // Press Enter to complete it
+    await page.keyboard.press("Enter");
+
+    // The search input should now contain both tags completed
+    await expect(searchInput).toHaveValue(`tag:${tag1} tag:${tag2} `);
+  });
 });

--- a/tests/autocomplete.spec.ts
+++ b/tests/autocomplete.spec.ts
@@ -1,0 +1,98 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("Search Autocomplete E2E", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/gallery");
+    await expect(page.getByTestId("loading-skeleton")).toBeHidden();
+  });
+
+  test("should show column suggestions when typing search prefix", async ({
+    page,
+  }) => {
+    const searchInput = page.getByPlaceholder(/Search \(e\.g\..*\)/).first();
+    await expect(searchInput).toBeVisible();
+
+    // Type the start of a column prefix
+    await searchInput.focus();
+    await searchInput.pressSequentially("ta", { delay: 50 });
+    await expect(searchInput).toHaveValue("ta");
+
+    // Dropdown should be visible
+    const dropdown = page.locator("#search-autocomplete-listbox");
+    await expect(dropdown).toBeVisible();
+
+    // Check suggestions list matching "ta"
+    const firstOption = page.locator("#suggestion-item-0");
+    await expect(firstOption).toBeVisible();
+    await expect(firstOption).toContainText("tag:");
+
+    // Press Tab to complete the column prefix
+    await page.keyboard.press("Tab");
+
+    // The input should now contain "tag:"
+    await expect(searchInput).toHaveValue("tag:");
+  });
+
+  test("should support keyboard navigation (Arrow keys and Enter)", async ({
+    page,
+  }) => {
+    const searchInput = page.getByPlaceholder(/Search \(e\.g\..*\)/).first();
+    await searchInput.focus();
+    await searchInput.pressSequentially("t", { delay: 50 });
+    await expect(searchInput).toHaveValue("t");
+
+    const dropdown = page.locator("#search-autocomplete-listbox");
+    await expect(dropdown).toBeVisible();
+
+    const firstOption = page.locator("#suggestion-item-0");
+    const secondOption = page.locator("#suggestion-item-1");
+
+    await expect(firstOption).toHaveAttribute("aria-selected", "true");
+    await expect(secondOption).toHaveAttribute("aria-selected", "false");
+
+    // Navigate to the next suggestion
+    await page.keyboard.press("ArrowDown");
+    await expect(firstOption).toHaveAttribute("aria-selected", "false");
+    await expect(secondOption).toHaveAttribute("aria-selected", "true");
+
+    // Select it
+    await page.keyboard.press("Enter");
+    const val = await searchInput.inputValue();
+    expect(val.toLowerCase()).toContain("title:");
+  });
+
+  test("should show static completions for source and extractor filters", async ({
+    page,
+  }) => {
+    const searchInput = page.getByPlaceholder(/Search \(e\.g\..*\)/).first();
+
+    await searchInput.focus();
+    await searchInput.pressSequentially("extractor:", { delay: 50 });
+    await expect(searchInput).toHaveValue("extractor:");
+
+    const dropdown = page.locator("#search-autocomplete-listbox");
+    await expect(dropdown).toBeVisible();
+
+    // Playwright automatically retries this assertion until the asynchronous static suggestions load!
+    await expect(dropdown).toContainText("twitter");
+    await expect(dropdown).toContainText("pixiv");
+
+    const suggestionCount = await page
+      .locator('[class*="suggestionItem"]')
+      .count();
+    expect(suggestionCount).toBeGreaterThanOrEqual(2);
+  });
+
+  test("should close dropdown on Escape press", async ({ page }) => {
+    const searchInput = page.getByPlaceholder(/Search \(e\.g\..*\)/).first();
+    await searchInput.focus();
+    await searchInput.pressSequentially("ta", { delay: 50 });
+    await expect(searchInput).toHaveValue("ta");
+
+    const dropdown = page.locator("#search-autocomplete-listbox");
+    await expect(dropdown).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(dropdown).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
# Walkthrough: Search Autocomplete (Issue #72)

I have successfully implemented the two-phase search autocomplete subsystem in the web-gallery application, complete with a context-aware co-occurrence tag recommendation engine. The features have been verified through successful type checks, compilation, and automatic end-to-end integration tests using Playwright.

---

## Refinement: Context-Aware Co-occurring Tags

We added a dynamic context-aware autocomplete mechanism for tags. When a user has already typed tag filters (e.g., `tag:tag1`) and types another tag filter prefix (e.g., `tag:`), the suggestions dropdown displays the most common tags that appear alongside `tag1` on the matching posts.

### 1. Extracting Context in useSearchAutocomplete Hook
- **[MODIFY] [useSearchAutocomplete.ts](src/hooks/useSearchAutocomplete.ts)**:
  - Inside the value suggestions fetcher, we locate the caret's word boundaries using `getWordAtCursor`.
  - We extract the "context query" (the search text excluding the active word being typed at the cursor).
  - We append this context query as the `&context` parameter to the API request.

### 2. Forwarding Context in API Handler
- **[MODIFY] [route.ts](src/app/api/autocomplete/route.ts)**:
  - Retrieves the optional `context` parameter from search parameters and forwards it to the `autocompleteTag` repository function.

### 3. Dynamic FTS5 Context Querying in Database Repository
- **[MODIFY] [autocomplete.ts](src/lib/db/repositories/autocomplete.ts)**:
  - Parses the context query using `parseSearchQuery` to split it into a clean search query and any `source:` filters.
  - Formulates a subquery over the virtual table `posts_fts MATCH` using SQLite's high-performance full-text indexing to locate all matching posts for the context.
  - Employs an `innerJoin` on `postTags` and the matched posts subquery to retrieve and count only tags that co-occur on the matching posts, sorting by frequency descending.
  - Implements a case-insensitive, Unicode-safe exclusion of already-typed tags extracted from the context utilizing a regex matcher matching non-whitespace sequences `\S+` (safely matching Japanese, Chinese, and emoji tag names).

### 4. UI Loading Spinner inside Autocomplete Dropdown
- **[MODIFY] [useSearchAutocomplete.ts](src/hooks/useSearchAutocomplete.ts)**:
  - Tracks `isLoading` status, setting it to `true` immediately when transitioning to `"value"` phase or when the user updates the query before/during debounce and fetch.
- **[MODIFY] [FilterBar.tsx](src/app/gallery/components/FilterBar.tsx) & [FilterBar.tsx](src/app/timeline/components/FilterBar.tsx)**:
  - Destructures `isLoading` from the autocomplete hook and passes it to the `AutocompleteDropdown`.
- **[MODIFY] [AutocompleteDropdown.tsx](src/components/AutocompleteDropdown.tsx) & [AutocompleteDropdown.module.css](src/components/AutocompleteDropdown.module.css)**:
  - Supports `isLoading` prop and updates empty lists check (`suggestions.length === 0 && !isLoading` returns null).
  - Renders a clean centered loading block with spin animations if the list is empty and fetching suggestions (`suggestions.length === 0 && isLoading`).
  - Renders an absolute-positioned top-right loader in the popover if suggestions already exist but are actively refreshing in the background (`suggestions.length > 0 && isLoading`), preventing layout shifting and showing real-time feedback.

### 5. Integration Verification
- **[MODIFY] [autocomplete.spec.ts](tests/autocomplete.spec.ts)**:
  - Added a new E2E integration test: `should show context-aware suggestions (co-occurring tags)`.
  - Dynamically extracts co-occurring tags directly from visible media items on `/gallery` to make the test data-independent.
  - Simulates typing the first tag, followed by typing the prefix of the second co-occurring tag.
  - Asserts that the dropdown popover dynamically queries co-occurring tags and suggests the second tag.
  - Asserts that pressing `Enter` successfully completes the query to include both tags.
  - Gracefully tests gallery count first, skipping automatically in CI pipelines if the database contains no posts with 2+ tags.