### PR TITLE
102 consider packaging releases with yao pkg

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -20,6 +20,9 @@ npm-debug.log
 # Build output
 .next
 
+# Standalone binary release folder
+dist
+
 # Docker / Compose
 Dockerfile*
 docker-compose*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,35 @@ jobs:
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v5
 
+      - name: Set up Node.js
+        if: ${{ steps.release.outputs.release_created }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm ci
+
+      - name: Build standalone binaries
+        if: ${{ steps.release.outputs.release_created }}
+        run: npm run build:release
+
+      - name: Create release archives
+        if: ${{ steps.release.outputs.release_created }}
+        run: |
+          tar -czf web-gallery-linux-x64.tar.gz -C dist web-gallery-linux setup-deps.sh
+          tar -czf web-gallery-macos-x64.tar.gz -C dist web-gallery-macos setup-deps.sh
+          zip -j web-gallery-windows-x64.zip dist/web-gallery-win.exe dist/setup-deps.ps1
+
+      - name: Upload release assets
+        if: ${{ steps.release.outputs.release_created }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload ${{ steps.release.outputs.tag_name }} web-gallery-linux-x64.tar.gz web-gallery-macos-x64.tar.gz web-gallery-windows-x64.zip
+
       - name: Set up QEMU
         if: ${{ steps.release.outputs.release_created }}
         uses: docker/setup-qemu-action@v3

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 
 # production
 /build
+/dist/
 
 # misc
 .DS_Store
@@ -45,6 +46,8 @@ next-env.d.ts
 # user generated files
 public/downloads/
 public/avatars/
+downloads/
+avatars/
 gallery-dl.conf
 gallery-dl.log
 *.sqlite3

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -523,6 +523,15 @@ docker compose -f compose.debug.yaml up  # With bind-mounted source
 docker compose -f compose.test.yaml up   # E2E test runner
 ```
 
+### Standalone Binary Packaging (Production Releases)
+
+Web Gallery can be compiled into a single executable binary for Linux, macOS, and Windows. This is designed for users who want to run the application natively without setting up a Node.js runtime or Docker.
+
+- **Packaging Engine**: `@yao-pkg/pkg` in **SEA (Single Executable Application)** Mode.
+- **Virtual File System (VFS)**: Frontend assets (`.next/static`, `public` favicon/images), database migrations (`drizzle/`), and configuration templates are packaged directly inside the executable. The VFS layer intercepts `fs` module operations and maps files to `/snapshot/web-gallery/` at runtime, allowing the app to read static files and run database migrations out of the binary itself.
+- **Data Persistence**: Writable operations (like database updates to `sqlite.db` or writing settings to `settings.json`) bypass the read-only VFS and resolve to the real host filesystem (falling back to the current working directory, or controlled via `DATA_DIR` and `MEDIA_DIR` environment variables). These environment variables, along with server port and hostname, can also be configured using a `.env` file placed next to the binary at runtime.
+- **Local Dependencies (`./bin/`)**: The scraper runner and dimension utilities search for `gallery-dl`, `ffmpeg`, and `ffprobe` in a local `./bin/` folder first. This enables a portable, self-contained deployment using setup scripts (`scripts/setup-deps.sh` or `scripts/setup-deps.ps1`) to download dependencies.
+
 **Security headers** (configured in `next.config.ts`, applied to all routes):
 - `X-Frame-Options: DENY`
 - `X-Content-Type-Options: nosniff`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,14 @@ Individual pages export their own `metadata` for custom titles (e.g., `export co
 
 - **Rule**: When implementing features that create or delete posts, media items, tags, users, or affect extractor coverage, you MUST update the pre-computed statistics. Use `incrementStatistics(delta)` for targeted counter adjustments (additions/deletions) or `recomputeStatistics()` for full accuracy after bulk operations. See `src/lib/db/repositories/statistics.ts`.
 
+### 1.15 Standalone Release Packaging
+
+This project supports compiling a dependency-free standalone binary using `@yao-pkg/pkg` in **SEA (Single Executable Application)** mode.
+
+- **Build Script**: Developers can run `npm run build:release` which triggers `scripts/build-release.js`. This script compiles Next.js in standalone mode, copies static assets/drizzle migrations, patches `server.js` to run in the VFS snapshot, and packages the binary.
+- **Rule**: When adding new static files, templates, or folders that must be bundled with the binary, you MUST update the `assets` list in the `"pkg"` config within `package.json` to ensure they are captured by the compiler.
+- **Rule**: Avoid hardcoded references to `process.cwd() + "/public"` or assuming system binaries are globally available. Always check for local binaries in `./bin` using the `getCommandPath` helper and use `path.dirname(paths.downloads)` to resolve public assets correctly.
+
 ---
 
 ## 2. General Coding Guidelines
@@ -260,4 +268,3 @@ When running E2E tests locally, Playwright targets the server hosted by the Dock
   Wait for the build to complete and the container to be healthy before running the E2E tests.
 
 ---
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ ENV NODE_ENV=production
 
 # Copy the standalone server output (includes traced node_modules)
 COPY --from=builder /usr/src/app/.next/standalone ./
+# Copy next-server compiled files which are missed by standalone tracer under Turbopack
+COPY --from=builder /usr/src/app/node_modules/next/dist/compiled/next-server ./node_modules/next/dist/compiled/next-server
 # Standalone doesn't include static assets — copy separately
 COPY --from=builder /usr/src/app/.next/static ./.next/static
 # Public directory (empty placeholders for symlinks created by entrypoint)

--- a/README.md
+++ b/README.md
@@ -110,6 +110,58 @@ The database migrations are applied automatically at startup when the applicatio
 > [!NOTE]
 > For production deployment, you can configure custom data/media storage folders by setting the `DATA_DIR` and `MEDIA_DIR` environment variables before starting the server. See [docs/configuration.md](./docs/configuration.md) for full reference.
 
+---
+
+### Option C: Standalone Package (Zero Node.js Setup)
+
+If you want to run Web Gallery directly on your host machine without installing Node.js/npm or running containers, you can use our pre-packaged standalone binary.
+
+#### 1. Download the Standalone Executable
+Download the compiled release binary for your platform (Linux, macOS, or Windows) from the Releases page.
+
+#### 2. Run the Dependency Installer
+Web Gallery requires `gallery-dl`, `ffmpeg`, and `ffprobe` to perform media scraping and process dimensions. We provide helper scripts in the release to download and configure these dependencies locally:
+
+- **Linux & macOS**:
+  ```bash
+  chmod +x scripts/setup-deps.sh
+  ./scripts/setup-deps.sh
+  ```
+- **Windows** (PowerShell):
+  ```powershell
+  .\scripts\setup-deps.ps1
+  ```
+
+This will automatically download and place the latest precompiled binaries (`gallery-dl`, `ffmpeg`, `ffprobe`) into a local `./bin/` folder. The application will automatically detect and prioritize these local binaries.
+
+#### 3. Run the Application
+Start the standalone server:
+
+- **Linux / macOS**:
+  ```bash
+  ./web-gallery-linux
+  ```
+- **Windows**:
+  ```cmd
+  web-gallery-win.exe
+  ```
+
+By default:
+- **Default Storage**: Writable application data and the database will be created in `./data/` (e.g. `./data/sqlite.db`), and downloaded media files will be saved in `./downloads/` inside the directory from which the executable is run.
+- **Console URL & Browser Launch**: The application prints the exact hosting URL (e.g., `[Server] Web Gallery is running at: http://localhost:3000`) and automatically attempts to open the site in your default system web browser.
+
+You can customize the host address and port by specifying the `HOSTNAME` and `PORT` environment variables:
+
+```bash
+# Example: Bind only to local loopback on port 8080
+HOSTNAME=127.0.0.1 PORT=8080 ./web-gallery-linux
+```
+
+Access the web interface at the printed URL (defaults to [http://localhost:3000](http://localhost:3000) or whichever hostname and port you configure).
+
+> [!NOTE]
+> You can override where the database, logs, and downloads are saved by setting `DATA_DIR` and `MEDIA_DIR` environment variables before executing the binary. Alternatively, you can place a `.env` file in the same directory as the executable, and the binary will automatically detect and load it on startup.
+
 ### Usage
 
 To start populating your timeline and gallery views with posts, you need to scrape some posts from a source.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,20 +8,23 @@ This document covers every configurable aspect of Web Gallery: environment varia
 
 All variables are optional. When unset, the application defaults to a self-contained development layout rooted at the current working directory.
 
+> [!TIP]
+> You can configure these environment variables by placing a `.env` file in the application root (or the directory containing the standalone binary). The application will automatically detect and load it on startup, resolving variables before starting the web server.
+
 ### Storage
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `DATA_DIR` | `process.cwd()` | Path for fast-access data: the SQLite database, scraper archives, and per-scrape log files. Put this on an SSD if possible. |
+| `DATA_DIR` | `path.join(process.cwd(), "data")` (i.e., `./data`) | Path for fast-access data: the SQLite database, scraper archives, and per-scrape log files. Put this on an SSD if possible. |
 | `MEDIA_DIR` | `process.cwd()` | Path for bulk media storage: downloaded media files and cached avatar images. Can be a separate, larger (HDD) volume. |
 
-When both are unset (typical in development), all data lands under the project root:
+When both are unset (typical in development / native binary runs), all data lands under the project root:
 
 ```
-./sqlite.db
-./public/downloads/   ← media files (served by Next.js static hosting)
-./public/avatars/     ← cached avatars
-./scrapers/gallery-dl/
+./data/sqlite.db
+./downloads/          ← media files (served by the dynamic media router)
+./avatars/            ← cached avatars
+./data/scrapers/gallery-dl/
 ```
 
 When set (Docker / production), paths resolve as:
@@ -60,15 +63,15 @@ gallery-dl is the scraping engine used to download media. The application manage
 
 | Mode | Path |
 |------|------|
-| Development (unset `DATA_DIR`) | `./scrapers/gallery-dl/gallery-dl.conf` |
+| Development (unset `DATA_DIR`) | `./data/scrapers/gallery-dl/gallery-dl.conf` |
 | Production / Docker | `$DATA_DIR/scrapers/gallery-dl/gallery-dl.conf` |
 
 A template with recommended defaults is included in the repository root as [`gallery-dl-default.conf`](../gallery-dl-default.conf). On first run the application does not automatically copy this — you should copy or symlink it yourself:
 
 ```bash
 # Development
-mkdir -p scrapers/gallery-dl
-cp gallery-dl-default.conf scrapers/gallery-dl/gallery-dl.conf
+mkdir -p data/scrapers/gallery-dl
+cp gallery-dl-default.conf data/scrapers/gallery-dl/gallery-dl.conf
 ```
 
 ### Key settings to configure

--- a/next.config.ts
+++ b/next.config.ts
@@ -26,6 +26,19 @@ const nextConfig: NextConfig = {
   // like @libsql/client.
   output: "standalone",
   serverExternalPackages: ["@libsql/client"],
+  outputFileTracingExcludes: {
+    "*": [
+      "./dist/**/*",
+      "./scratch/**/*",
+      "./tests/**/*",
+      "./playwright.config.ts",
+      "./test-results/**/*",
+      "./test-data/**/*",
+      "./test-media/**/*",
+      "./sqlite.db",
+      "./.env",
+    ],
+  },
   images: {
     // Wildcard patterns needed for scraper-sourced content from arbitrary domains.
     // Local paths (e.g. /downloads/...) are served directly and don't require these,

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,137 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@yao-pkg/pkg": "^6.20.0",
         "drizzle-kit": "^0.31.8",
         "husky": "^9.1.7",
         "lint-staged": "^16.4.0",
         "typescript": "5.9.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@biomejs/biome": {
@@ -1554,6 +1681,58 @@
         "url": "https://opencollective.com/libvips"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
     "node_modules/@libsql/client": {
       "version": "0.15.15",
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.15.15.tgz",
@@ -1916,6 +2095,16 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/@roberts_lando/vfs": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@roberts_lando/vfs/-/vfs-0.3.3.tgz",
+      "integrity": "sha512-YjkxVSLw5WMZQoARaryRAjcxA+GbBzWMJdwYZX5oLUt9cC/gew9as4Dn7tcLzPp7BPoR221VpTZ+78TRPawnjg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 22"
+      }
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2044,6 +2233,577 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@yao-pkg/pkg": {
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg/-/pkg-6.20.0.tgz",
+      "integrity": "sha512-RyYHHA1GmU2kEpNXUlknxekLftROewApqky6KpJK7ErreyMK8ysdkLmJOyo7XmuRhedVL+iuvmzYxfwgEYyAsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/generator": "^7.23.0",
+        "@babel/parser": "^7.23.0",
+        "@babel/traverse": "^7.23.0",
+        "@babel/types": "^7.23.0",
+        "@roberts_lando/vfs": "^0.3.3",
+        "@yao-pkg/pkg-fetch": "3.6.3",
+        "esbuild": "^0.27.3",
+        "into-stream": "^9.1.0",
+        "multistream": "^4.1.0",
+        "picocolors": "^1.1.0",
+        "picomatch": "^4.0.2",
+        "postject": "^1.0.0-alpha.6",
+        "prebuild-install": "^7.1.1",
+        "resolve": "^1.22.10",
+        "resolve.exports": "^2.0.3",
+        "stream-meter": "^1.0.4",
+        "tar": "^7.5.7",
+        "tinyglobby": "^0.2.11",
+        "unzipper": "^0.12.3"
+      },
+      "bin": {
+        "pkg": "lib-es5/bin.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@yao-pkg/pkg-fetch": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/@yao-pkg/pkg-fetch/-/pkg-fetch-3.6.3.tgz",
+      "integrity": "sha512-EAOgiH5viuZP//ZJ2vQMgkAId2GERx1A7ccjXtlpEbXlqAtXAmnvh6IQ1I7HeJSNBQ+dKq32lqDgz5N2oAsjkA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.6",
+        "picocolors": "^1.1.0",
+        "progress": "^2.0.3",
+        "semver": "^7.3.5",
+        "tar-fs": "^3.1.1",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "pkg-fetch": "lib-es5/bin.js"
+      }
+    },
+    "node_modules/@yao-pkg/pkg-fetch/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@yao-pkg/pkg/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ansi-escapes": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
@@ -2086,6 +2846,139 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
+      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.2.tgz",
+      "integrity": "sha512-aTvMFUWkBmjzKtEQMDGGDNF8bkfpD5N1b/FCwt7A3wrU4t1o/e/85Wzkluh6JlODCjqVESYCkQCdTXqZ9G7VFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.1.tgz",
+      "integrity": "sha512-ghj2DSK/2e99a1anTVPCV4m4YIYtrbXhfM7V3D7XZLOTsybnYyaJloymGqssQc8l/or0UoDyRtNQkmkEF/ysgQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.2.tgz",
+      "integrity": "sha512-2V5j0dOfxv3iIngIWMnW1O6UPXpeoU70HJzUJGVth/+RURhDyq7SEWTD70Y2SkUB0MQonYYWpIX3f85P/I22+Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
+      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.14",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.14.tgz",
@@ -2093,6 +2986,50 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -2121,6 +3058,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
@@ -2161,6 +3108,107 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -2169,6 +3217,26 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/colorette": {
       "version": "2.0.20",
@@ -2186,6 +3254,13 @@
       "engines": {
         "node": ">=20"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/croner": {
       "version": "10.0.1",
@@ -2377,12 +3452,38 @@
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2528,12 +3629,65 @@
         }
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "10.6.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/environment": {
       "version": "1.1.0",
@@ -2546,6 +3700,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-toolkit": {
@@ -2613,11 +3777,66 @@
         "esbuild": ">=0.12 <1"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "dev": true,
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fetch-blob": {
       "version": "3.2.0",
@@ -2654,6 +3873,28 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.5.tgz",
+      "integrity": "sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -2667,6 +3908,26 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-east-asian-width": {
@@ -2695,6 +3956,47 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/husky": {
       "version": "9.1.7",
       "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
@@ -2711,6 +4013,27 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/immer": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
@@ -2721,6 +4044,20 @@
         "url": "https://opencollective.com/immer"
       }
     },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2728,6 +4065,35 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/into-stream": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-9.1.0.tgz",
+      "integrity": "sha512-DRsRnQrbzdFjaQ1oe4C6/EIUymIOEix1qROEJTF9dbMq+M4Zrm6VaLp6SD/B9IsiEjPZuBSnWWFN+udajugdWA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -2746,11 +4112,51 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-base64": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
       "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "node_modules/libsql": {
       "version": "0.5.29",
@@ -2894,12 +4300,90 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+      "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/multistream": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/multistream/-/multistream-4.1.0.tgz",
+      "integrity": "sha512-J1XDiAmmNpRCBfIWJv+n0ymC4ABcf/Pl+5YvC5B/D2f/2+8PtHvCNxMPKiQcZyi922Hq69J2YOpb1pTywfifyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0",
+        "readable-stream": "^3.6.0"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -2918,6 +4402,13 @@
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
+    },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/next": {
       "version": "16.1.1",
@@ -2972,6 +4463,19 @@
         }
       }
     },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/node-domexception": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
@@ -3010,6 +4514,23 @@
         "url": "https://opencollective.com/node-fetch"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/onetime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
@@ -3025,6 +4546,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3105,11 +4633,146 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postject": {
+      "version": "1.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/postject/-/postject-1.0.0-alpha.6.tgz",
+      "integrity": "sha512-b9Eb8h2eVqNE8edvKdwqkrY6O7kAwmI8kcnBv1NScolYJbo59XUF0noFq+lxbC1yN20bmC0WBEbDC5H/7ASb0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.4.0"
+      },
+      "bin": {
+        "postject": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/postject/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise-limit": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/promise-limit/-/promise-limit-2.7.0.tgz",
       "integrity": "sha512-7nJ6v5lnJsXwGprnGXga4wx6d1POjvi5Qmf1ivTRxTjH4Z/9Czja/UCMLVmB9N93GeWOU93XaFaEt6jbuoagNw==",
       "license": "ISC"
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
     },
     "node_modules/react": {
       "version": "19.2.3",
@@ -3162,6 +4825,21 @@
         }
       }
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/recharts": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
@@ -3207,11 +4885,43 @@
         "redux": "^5.0.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/reselect": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
+    },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/resolve-pkg-maps": {
       "version": "1.0.0",
@@ -3221,6 +4931,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/restore-cursor": {
@@ -3247,11 +4967,45 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
       "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -3298,19 +5052,6 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
-    "node_modules/sharp/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "license": "ISC",
-      "optional": true,
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -3322,6 +5063,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "node_modules/slice-ansi": {
@@ -3371,6 +5159,71 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/stream-meter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
+      "integrity": "sha512-4sOEtrbgFotXwnEuzzsQBYEV1elAeFSO8rSGeTwabuX1RRn/kEq9JVH7I0MRBhKVRR0sJkr0M0QCH7yOLf9fhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.1.4"
+      }
+    },
+    "node_modules/stream-meter/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/stream-meter/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stream-meter/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.27.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.27.0.tgz",
+      "integrity": "sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -3414,6 +5267,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -3437,6 +5300,84 @@
         }
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -3453,11 +5394,48 @@
         "node": ">=18"
       }
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -3479,6 +5457,30 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unzipper": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.12.3.tgz",
+      "integrity": "sha512-PZ8hTS+AqcGxsaQntl3IRBw65QrBI6lxzqDEL7IAo/XCEqRTKGfOX56Vea5TH9SZczRVxuzk1re04z/YjuYCJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "~3.7.2",
+        "duplexer2": "~0.1.4",
+        "fs-extra": "^11.2.0",
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      }
+    },
     "node_modules/use-sync-external-store": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
@@ -3487,6 +5489,13 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/victory-vendor": {
       "version": "37.3.6",
@@ -3517,6 +5526,24 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/wrap-ansi": {
@@ -3555,6 +5582,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/ws": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
@@ -3576,6 +5610,26 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -3590,6 +5644,90 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "web-gallery",
   "version": "0.3.0",
   "private": true,
+  "bin": "server.js",
   "scripts": {
     "dev": "next dev",
     "build": "next build",
@@ -10,7 +11,8 @@
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate",
     "test:e2e": "playwright test",
-    "prepare": "husky"
+    "prepare": "husky",
+    "build:release": "node scripts/build-release.js"
   },
   "dependencies": {
     "@libsql/client": "^0.15.0",
@@ -29,6 +31,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@yao-pkg/pkg": "^6.20.0",
     "drizzle-kit": "^0.31.8",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
@@ -37,6 +40,20 @@
   "lint-staged": {
     "*.(js|jsx|ts|tsx|json|css)": [
       "npx biome check --write --no-errors-on-unmatched"
+    ]
+  },
+  "pkg": {
+    "assets": [
+      ".next/**/*",
+      "public/**/*",
+      "drizzle/**/*",
+      "gallery-dl-default.conf",
+      "node_modules/**/*"
+    ],
+    "targets": [
+      "node22-linux-x64",
+      "node22-macos-x64",
+      "node22-win-x64"
     ]
   }
 }

--- a/scripts/build-release.js
+++ b/scripts/build-release.js
@@ -1,0 +1,347 @@
+const { execSync } = require("child_process");
+const fs = require("fs");
+const path = require("path");
+
+function copyDirSync(src, dest) {
+  fs.mkdirSync(dest, { recursive: true });
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+
+  for (const entry of entries) {
+    const srcPath = path.join(src, entry.name);
+    const destPath = path.join(dest, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirSync(srcPath, destPath);
+    } else {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+async function main() {
+  const rootDir = path.resolve(__dirname, "..");
+  const standaloneDir = path.join(rootDir, ".next", "standalone");
+  const distDir = path.join(rootDir, "dist");
+
+  console.log("1. Building Next.js standalone application...");
+  execSync("npm run build", { stdio: "inherit", cwd: rootDir });
+
+  console.log("2. Copying frontend static and public assets...");
+
+  // Copy static assets
+  const staticSrc = path.join(rootDir, ".next", "static");
+  const staticDest = path.join(standaloneDir, ".next", "static");
+  if (fs.existsSync(staticSrc)) {
+    console.log(`Copying .next/static to ${staticDest}`);
+    copyDirSync(staticSrc, staticDest);
+  }
+
+  // Copy public assets (excluding downloads and avatars folders)
+  const publicSrc = path.join(rootDir, "public");
+  const publicDest = path.join(standaloneDir, "public");
+  if (fs.existsSync(publicSrc)) {
+    fs.mkdirSync(publicDest, { recursive: true });
+    const publicEntries = fs.readdirSync(publicSrc, { withFileTypes: true });
+    for (const entry of publicEntries) {
+      if (entry.name === "downloads" || entry.name === "avatars") {
+        continue; // Exclude compiled downloads/avatars media caches
+      }
+      const srcPath = path.join(publicSrc, entry.name);
+      const destPath = path.join(publicDest, entry.name);
+      if (entry.isDirectory()) {
+        copyDirSync(srcPath, destPath);
+      } else {
+        fs.copyFileSync(srcPath, destPath);
+      }
+    }
+  }
+
+  console.log("3. Copying database migrations and default templates...");
+
+  // Copy drizzle migrations
+  const migrationsSrc = path.join(rootDir, "drizzle");
+  const migrationsDest = path.join(standaloneDir, "drizzle");
+  if (fs.existsSync(migrationsSrc)) {
+    copyDirSync(migrationsSrc, migrationsDest);
+  }
+
+  // Copy default config template
+  const configTemplate = path.join(rootDir, "gallery-dl-default.conf");
+  const configDest = path.join(standaloneDir, "gallery-dl-default.conf");
+  if (fs.existsSync(configTemplate)) {
+    fs.copyFileSync(configTemplate, configDest);
+  }
+
+  // Copy next-server compiled files for Turbopack runtime
+  const nextServerSrc = path.join(
+    rootDir,
+    "node_modules",
+    "next",
+    "dist",
+    "compiled",
+    "next-server",
+  );
+  const nextServerDest = path.join(
+    standaloneDir,
+    "node_modules",
+    "next",
+    "dist",
+    "compiled",
+    "next-server",
+  );
+  if (fs.existsSync(nextServerSrc)) {
+    console.log(`Copying next-server files to ${nextServerDest}`);
+    copyDirSync(nextServerSrc, nextServerDest);
+  }
+
+  console.log(
+    "4. Patching standalone server.js to run in virtual snapshot and mock inspector...",
+  );
+  const serverJsPath = path.join(standaloneDir, "server.js");
+  if (fs.existsSync(serverJsPath)) {
+    let serverJs = fs.readFileSync(serverJsPath, "utf8");
+    // Comment out process.chdir(__dirname)
+    serverJs = serverJs.replace(
+      "process.chdir(__dirname)",
+      "// process.chdir(__dirname)",
+    );
+
+    // Inject node:inspector, inspector mock, env loader, and libsql redirection at the very top of server.js
+    const inspectorMock = `
+// Load local .env file from current working directory if it exists
+try {
+  const fs = require('fs');
+  const path = require('path');
+  const envPath = path.join(process.cwd(), '.env');
+  if (fs.existsSync(envPath)) {
+    if (typeof process.loadEnvFile === 'function') {
+      process.loadEnvFile(envPath);
+      console.log(\`[Server] Loaded environment variables from \${envPath}\`);
+    } else {
+      // Fallback parser if running on older node versions
+      const dotenvContent = fs.readFileSync(envPath, 'utf8');
+      for (const line of dotenvContent.split(/\\r?\\n/)) {
+        const match = line.match(/^\\s*([^#\\s=]+)\\s*=\\s*(.*)$/);
+        if (match) {
+          const key = match[1];
+          let val = match[2].trim();
+          if (val.startsWith('"') && val.endsWith('"')) val = val.slice(1, -1);
+          else if (val.startsWith("'") && val.endsWith("'")) val = val.slice(1, -1);
+          process.env[key] = val;
+        }
+      }
+      console.log(\`[Server] Loaded environment variables (parsed) from \${envPath}\`);
+    }
+  }
+} catch (err) {
+  console.error(\`[Server] Failed to load .env file: \${err.message}\`);
+}
+
+// Mock inspector module which is missing in pkg base binaries and redirect hashed libsql requests
+const Module = require('module');
+const originalRequire = Module.prototype.require;
+Module.prototype.require = function(request) {
+  if (request === 'node:inspector' || request === 'inspector') {
+    return {
+      Session: class Session {
+        connect() {}
+        disconnect() {}
+        post() {}
+        on() {}
+      },
+      console: {},
+      url: () => null,
+      open: () => {},
+      close: () => {},
+      waitForDebugger: () => {},
+    };
+  }
+  if (typeof request === 'string' && request.startsWith('@libsql/client-')) {
+    return originalRequire.call(this, '@libsql/client');
+  }
+  return originalRequire.apply(this, arguments);
+};
+`;
+    serverJs = inspectorMock + "\n" + serverJs;
+
+    // Patch startServer call to print URL and auto-open default browser
+    const replacementStartServer = `startServer({
+  dir,
+  isDev: false,
+  config: nextConfig,
+  hostname,
+  port: currentPort,
+  allowRetry: false,
+  keepAliveTimeout,
+}).then(() => {
+  const host = process.env.HOSTNAME || 'localhost';
+  const openHost = (host === '0.0.0.0' || host === '::') ? 'localhost' : host;
+  const url = \`http://\${openHost}:\${currentPort}\`;
+  console.log(\`\\n[Server] Web Gallery is running at: \${url}\`);
+  console.log(\`[Server] Opening \${url} in your default browser...\\n\`);
+  
+  const { exec } = require('child_process');
+  let command;
+  switch (process.platform) {
+    case 'darwin':
+      command = \`open "\${url}"\`;
+      break;
+    case 'win32':
+      command = \`start "" "\${url}"\`;
+      break;
+    default:
+      command = \`xdg-open "\${url}"\`;
+      break;
+  }
+  exec(command, (err) => {
+    if (err) {
+      // Ignore errors if no GUI is present
+    }
+  });
+}).catch((err) => {
+  console.error(err);
+  process.exit(1);
+});`;
+
+    serverJs = serverJs.replace(
+      /startServer\(\{[\s\S]+?\}\)\.catch\(\(err\) => \{\s*console\.error\(err\);\s*process\.exit\(1\);\s*\}\);/,
+      replacementStartServer,
+    );
+
+    fs.writeFileSync(serverJsPath, serverJs, "utf8");
+    console.log(
+      "Successfully patched server.js with VFS patch, inspector mock, and browser auto-open",
+    );
+  } else {
+    throw new Error("server.js not found in .next/standalone/");
+  }
+
+  console.log(
+    "4.2. Pruning unwanted files and directories from standalone bundle...",
+  );
+  const pathsToPrune = [
+    path.join(standaloneDir, "scratch"),
+    path.join(standaloneDir, "dist"),
+    path.join(standaloneDir, "tests"),
+    path.join(standaloneDir, "test-results"),
+    path.join(standaloneDir, "test-data"),
+    path.join(standaloneDir, "test-media"),
+    path.join(standaloneDir, "public", "downloads"),
+    path.join(standaloneDir, "public", "avatars"),
+    path.join(standaloneDir, "sqlite.db"),
+    path.join(standaloneDir, ".env"),
+  ];
+
+  for (const prunePath of pathsToPrune) {
+    if (fs.existsSync(prunePath)) {
+      console.log(`Pruning: ${prunePath}`);
+      fs.rmSync(prunePath, { recursive: true, force: true });
+    }
+  }
+
+  console.log(
+    "4.3. Patching [turbopack]_runtime.js files in standalone bundle...",
+  );
+  const target =
+    "async function externalImport(id) {\n    let raw;\n    try {\n        raw = await import(id);\n    } catch (err) {\n        // TODO(alexkirsz) This can happen when a client-side module tries to load\n        // an external module we don't provide a shim for (e.g. querystring, url).\n        // For now, we fail semi-silently, but in the future this should be a\n        // compilation error.\n        throw new Error(`Failed to load external module ${id}: ${err}`);\n    }";
+
+  const replacement =
+    "async function externalImport(id) {\n    let raw;\n    try {\n        raw = await import(id);\n    } catch (err) {\n        try {\n            raw = require(id);\n        } catch (err2) {\n            // TODO(alexkirsz) This can happen when a client-side module tries to load\n            // an external module we don't provide a shim for (e.g. querystring, url).\n            // For now, we fail semi-silently, but in the future this should be a\n            // compilation error.\n            throw new Error(`Failed to load external module ${id}: ${err}`);\n        }\n    }";
+
+  function patchRuntimesRecursive(dir) {
+    if (!fs.existsSync(dir)) return;
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        patchRuntimesRecursive(fullPath);
+      } else if (entry.isFile() && entry.name === "[turbopack]_runtime.js") {
+        let content = fs.readFileSync(fullPath, "utf8");
+        if (content.includes(target)) {
+          content = content.replace(target, replacement);
+          fs.writeFileSync(fullPath, content, "utf8");
+          console.log(`Successfully patched externalImport in: ${fullPath}`);
+        } else {
+          console.warn(`Warning: target string not found in: ${fullPath}`);
+        }
+      }
+    }
+  }
+
+  const chunksDir = path.join(standaloneDir, ".next", "server", "chunks");
+  patchRuntimesRecursive(chunksDir);
+
+  console.log(
+    "4.4. Patching JS files to redirect hashed libsql client imports...",
+  );
+  function patchLibsqlImports(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        patchLibsqlImports(fullPath);
+      } else if (entry.isFile() && entry.name.endsWith(".js")) {
+        let content = fs.readFileSync(fullPath, "utf8");
+        if (content.includes("@libsql/client-")) {
+          console.log(`Patching libsql client import in: ${fullPath}`);
+          content = content.replace(
+            /@libsql\/client-[a-f0-9]+/g,
+            "@libsql/client",
+          );
+          fs.writeFileSync(fullPath, content, "utf8");
+        }
+      }
+    }
+  }
+  patchLibsqlImports(standaloneDir);
+
+  console.log("4.5. Cleaning up symlinks inside standalone directory...");
+  function cleanSymlinksRecursive(dir) {
+    const entries = fs.readdirSync(dir, { withFileTypes: true });
+    for (const entry of entries) {
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isSymbolicLink()) {
+        console.log(`Removing symlink: ${fullPath}`);
+        fs.unlinkSync(fullPath);
+      } else if (entry.isDirectory()) {
+        cleanSymlinksRecursive(fullPath);
+      }
+    }
+  }
+  cleanSymlinksRecursive(standaloneDir);
+
+  console.log("5. Packaging application using @yao-pkg/pkg in SEA mode...");
+  fs.mkdirSync(distDir, { recursive: true });
+
+  // Run pkg in standalone directory targeting package.json (which contains bin and pkg configuration)
+  // Outputs to the root dist/ directory
+  execSync(`npx pkg . --out-path "${distDir}"`, {
+    stdio: "inherit",
+    cwd: standaloneDir,
+  });
+
+  console.log("6. Copying dependency setup scripts to release package...");
+  const shSrc = path.join(rootDir, "scripts", "setup-deps.sh");
+  const shDest = path.join(distDir, "setup-deps.sh");
+  if (fs.existsSync(shSrc)) {
+    fs.copyFileSync(shSrc, shDest);
+    fs.chmodSync(shDest, 0o755); // make executable
+    console.log("Copied setup-deps.sh to dist/");
+  }
+
+  const ps1Src = path.join(rootDir, "scripts", "setup-deps.ps1");
+  const ps1Dest = path.join(distDir, "setup-deps.ps1");
+  if (fs.existsSync(ps1Src)) {
+    fs.copyFileSync(ps1Src, ps1Dest);
+    console.log("Copied setup-deps.ps1 to dist/");
+  }
+
+  console.log(
+    `\nSuccess! Standalone binaries and setup scripts generated in ${distDir}`,
+  );
+}
+
+main().catch((err) => {
+  console.error("Build failed:", err);
+  process.exit(1);
+});

--- a/scripts/setup-deps.ps1
+++ b/scripts/setup-deps.ps1
@@ -1,0 +1,43 @@
+$ErrorActionPreference = "Stop"
+
+# Create local bin directory
+If (!(Test-Path -Path "bin")) {
+    New-Item -ItemType Directory -Path "bin" | Out-Null
+}
+
+Write-Host "Fetching latest gallery-dl release version..."
+$GalleryDlVersion = "v1.28.5" # Fallback version if request fails
+try {
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    $Response = Invoke-RestMethod -Uri "https://codeberg.org/api/v1/repos/mikf/gallery-dl/releases/latest" -UseBasicParsing
+    If ($Response.tag_name) {
+        $GalleryDlVersion = $Response.tag_name
+        Write-Host "Latest version found: $GalleryDlVersion"
+    }
+} catch {
+    Write-Host "Failed to fetch latest version, falling back to $GalleryDlVersion"
+}
+
+$GalleryDlUrl = "https://codeberg.org/mikf/gallery-dl/releases/download/$GalleryDlVersion/gallery-dl.exe"
+$FfmpegUrl = "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffmpeg-6.1-win-64.zip"
+$FfprobeUrl = "https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffprobe-6.1-win-64.zip"
+
+Write-Host "Downloading gallery-dl.exe..."
+Invoke-WebRequest -Uri $GalleryDlUrl -OutFile "bin\gallery-dl.exe" -UseBasicParsing
+
+Write-Host "Downloading ffmpeg..."
+Invoke-WebRequest -Uri $FfmpegUrl -OutFile "bin\ffmpeg.zip" -UseBasicParsing
+Write-Host "Downloading ffprobe..."
+Invoke-WebRequest -Uri $FfprobeUrl -OutFile "bin\ffprobe.zip" -UseBasicParsing
+
+Write-Host "Extracting ffmpeg and ffprobe..."
+Expand-Archive -Path "bin\ffmpeg.zip" -DestinationPath "bin" -Force
+Expand-Archive -Path "bin\ffprobe.zip" -DestinationPath "bin" -Force
+
+# Clean up zips
+Remove-Item -Path "bin\ffmpeg.zip" -Force
+Remove-Item -Path "bin\ffprobe.zip" -Force
+
+Write-Host "Dependencies successfully installed locally in .\bin\!"
+& .\bin\gallery-dl.exe --version
+& .\bin\ffprobe.exe -version | Select-Object -First 1

--- a/scripts/setup-deps.sh
+++ b/scripts/setup-deps.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -e
+
+# Create local bin folder
+mkdir -p bin
+
+# Detect OS
+OS_NAME=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH_NAME=$(uname -m)
+
+echo "Detected OS: $OS_NAME ($ARCH_NAME)"
+
+# Define download urls
+GALLERY_DL_VERSION="v1.28.5" # Fallback version if API fetch fails
+FFMPEG_URL=""
+FFPROBE_URL=""
+GALLERY_DL_URL=""
+
+# Fetch latest gallery-dl version from Codeberg API
+echo "Fetching latest gallery-dl release version..."
+LATEST_TAG=$(curl -s https://codeberg.org/api/v1/repos/mikf/gallery-dl/releases/latest | grep -o '"tag_name": *"[^"]*"' | head -n 1 | cut -d'"' -f4 || true)
+if [ -n "$LATEST_TAG" ]; then
+    GALLERY_DL_VERSION="$LATEST_TAG"
+    echo "Latest version found: $GALLERY_DL_VERSION"
+else
+    echo "Failed to fetch latest version, falling back to $GALLERY_DL_VERSION"
+fi
+
+if [ "$OS_NAME" = "linux" ]; then
+    GALLERY_DL_URL="https://codeberg.org/mikf/gallery-dl/releases/download/${GALLERY_DL_VERSION}/gallery-dl.bin"
+    FFMPEG_URL="https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffmpeg-6.1-linux-64.zip"
+    FFPROBE_URL="https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffprobe-6.1-linux-64.zip"
+elif [ "$OS_NAME" = "darwin" ]; then
+    GALLERY_DL_URL="https://codeberg.org/mikf/gallery-dl/releases/download/${GALLERY_DL_VERSION}/gallery-dl.bin"
+    FFMPEG_URL="https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffmpeg-6.1-osx-64.zip"
+    FFPROBE_URL="https://github.com/ffbinaries/ffbinaries-prebuilt/releases/download/v6.1/ffprobe-6.1-osx-64.zip"
+else
+    echo "Unsupported OS for setup-deps.sh. Please install dependencies manually."
+    exit 1
+fi
+
+# 1. Download gallery-dl
+echo "Downloading gallery-dl..."
+curl -L -o bin/gallery-dl "$GALLERY_DL_URL"
+chmod +x bin/gallery-dl
+
+# 2. Download and extract ffmpeg / ffprobe
+echo "Downloading ffmpeg..."
+curl -L -o bin/ffmpeg.zip "$FFMPEG_URL"
+echo "Downloading ffprobe..."
+curl -L -o bin/ffprobe.zip "$FFPROBE_URL"
+
+echo "Extracting ffmpeg and ffprobe..."
+if command -v unzip >/dev/null; then
+    unzip -o bin/ffmpeg.zip -d bin
+    unzip -o bin/ffprobe.zip -d bin
+else
+    echo "Error: unzip is not installed. Please install unzip or manually extract bin/ffmpeg.zip and bin/ffprobe.zip."
+    exit 1
+fi
+
+# Cleanup zips
+rm -f bin/ffmpeg.zip bin/ffprobe.zip
+chmod +x bin/ffmpeg bin/ffprobe
+
+echo "Dependencies successfully installed locally in ./bin/!"
+./bin/gallery-dl --version
+./bin/ffprobe -version | head -n 1

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,5 +1,15 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    const fs = await import("node:fs");
+    const { paths } = await import("@/lib/config");
+
+    // Ensure critical local storage directories exist
+    for (const dir of [paths.dataDir, paths.downloads, paths.avatars]) {
+      if (!fs.existsSync(dir)) {
+        fs.mkdirSync(dir, { recursive: true });
+      }
+    }
+
     const { initDb } = await import("@/lib/db");
     await initDb();
 

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -25,9 +25,8 @@ import path from "node:path";
  * symlinks from those public dirs to the MEDIA_DIR locations.
  */
 
-const DATA_DIR = process.env.DATA_DIR || process.cwd();
+const DATA_DIR = process.env.DATA_DIR || path.join(process.cwd(), "data");
 const MEDIA_DIR = process.env.MEDIA_DIR || process.cwd();
-const hasMediaDir = !!process.env.MEDIA_DIR;
 
 export const paths = {
   /** Root data directory (fast storage — DB, scraper state) */
@@ -41,21 +40,13 @@ export const paths = {
 
   /**
    * Downloaded media files (bulk storage, served at /downloads/).
-   *
-   * When MEDIA_DIR is set (Docker): files live directly under $MEDIA_DIR/downloads/
-   * When MEDIA_DIR is unset (dev):  files live under ./public/downloads/ (Next.js static serving)
    */
-  downloads: hasMediaDir
-    ? path.join(MEDIA_DIR, "downloads")
-    : path.join(MEDIA_DIR, "public", "downloads"),
+  downloads: path.join(MEDIA_DIR, "downloads"),
 
   /**
    * Cached avatar images (bulk storage, served at /avatars/).
-   * Same MEDIA_DIR logic as downloads.
    */
-  avatars: hasMediaDir
-    ? path.join(MEDIA_DIR, "avatars")
-    : path.join(MEDIA_DIR, "public", "avatars"),
+  avatars: path.join(MEDIA_DIR, "avatars"),
 
   /** Root directory for scraper-related data (fast storage) */
   scraperData: path.join(DATA_DIR, "scrapers"),

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -6,13 +6,39 @@ import { drizzle } from "drizzle-orm/libsql";
 import { paths } from "@/lib/config";
 import * as schema from "@/lib/db/schema";
 
+// Ensure the directory containing the SQLite database exists
+const dbDir = path.dirname(paths.db);
+if (!fs.existsSync(dbDir)) {
+  fs.mkdirSync(dbDir, { recursive: true });
+}
+
 const dbUrl = `file:${paths.db}`;
 
 const client = createClient({ url: dbUrl });
 export const db = drizzle(client, { schema });
 
 const MIGRATIONS_TABLE = "__drizzle_migrations";
-const migrationsFolder = path.join(process.cwd(), "drizzle");
+const getMigrationsFolder = () => {
+  const localFolder = path.join(process.cwd(), "drizzle");
+  if (fs.existsSync(localFolder)) {
+    return localFolder;
+  }
+  // Try to find drizzle folder at various VFS levels in packaged mode
+  const pathsToTry = [
+    path.join(__dirname, "..", "..", "..", "drizzle"),
+    path.join(__dirname, "..", "..", "..", "..", "drizzle"),
+    path.join(__dirname, "..", "..", "..", "..", "..", "drizzle"),
+    "/snapshot/web-gallery/drizzle",
+    "/snapshot/web-gallery/.next/standalone/drizzle",
+  ];
+  for (const p of pathsToTry) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+  return localFolder;
+};
+const migrationsFolder = getMigrationsFolder();
 
 interface MigrationEntry {
   tag: string;

--- a/src/lib/db/repositories/media.ts
+++ b/src/lib/db/repositories/media.ts
@@ -13,6 +13,7 @@ import {
   type SQL,
   sql,
 } from "drizzle-orm";
+import { paths } from "@/lib/config";
 import { db } from "@/lib/db";
 import { incrementStatistics } from "@/lib/db/repositories/statistics";
 import {
@@ -277,7 +278,7 @@ export async function deleteMediaItems(ids: number[], deleteFiles: boolean) {
       .from(mediaItems)
       .where(inArray(mediaItems.id, ids));
 
-    const publicRoot = path.resolve(process.cwd(), "public");
+    const publicRoot = path.dirname(paths.downloads);
 
     for (const item of itemsToDelete) {
       try {

--- a/src/lib/library/processors/gelbooru.ts
+++ b/src/lib/library/processors/gelbooru.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { eq } from "drizzle-orm";
+import { paths } from "@/lib/config";
 import { postDetailsGelbooruV02, posts, postTags, tags } from "@/lib/db/schema";
 import type { IMetadataProcessor } from "@/lib/library/processors/base";
 import type { ProcessorContext, ProcessTask } from "@/lib/library/types";
@@ -64,7 +65,7 @@ export class GelbooruProcessor implements IMetadataProcessor<GelbooruMeta> {
             url: `https://gelbooru.com/index.php?page=post&s=view&id=${idStr}`,
             metadataPath: task.jsonPath
               ? path
-                  .relative(path.join(process.cwd(), "public"), task.jsonPath)
+                  .relative(path.dirname(paths.downloads), task.jsonPath)
                   .split(path.sep)
                   .join("/")
               : null,
@@ -129,7 +130,7 @@ export class GelbooruProcessor implements IMetadataProcessor<GelbooruMeta> {
           }
           if (task.jsonPath) {
             updateSet.metadataPath = path
-              .relative(path.join(process.cwd(), "public"), task.jsonPath)
+              .relative(path.dirname(paths.downloads), task.jsonPath)
               .split(path.sep)
               .join("/");
           }

--- a/src/lib/library/processors/pixiv.ts
+++ b/src/lib/library/processors/pixiv.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { eq } from "drizzle-orm";
+import { paths } from "@/lib/config";
 import {
   pixivUsers,
   postDetailsPixiv,
@@ -113,7 +114,7 @@ export class PixivProcessor implements IMetadataProcessor<PixivMeta> {
             url: `https://www.pixiv.net/artworks/${pid}`,
             metadataPath: task.jsonPath
               ? path
-                  .relative(path.join(process.cwd(), "public"), task.jsonPath)
+                  .relative(path.dirname(paths.downloads), task.jsonPath)
                   .split(path.sep)
                   .join("/")
               : null,
@@ -168,7 +169,7 @@ export class PixivProcessor implements IMetadataProcessor<PixivMeta> {
           }
           if (task.jsonPath) {
             updateSet.metadataPath = path
-              .relative(path.join(process.cwd(), "public"), task.jsonPath)
+              .relative(path.dirname(paths.downloads), task.jsonPath)
               .split(path.sep)
               .join("/");
           }

--- a/src/lib/library/processors/twitter.ts
+++ b/src/lib/library/processors/twitter.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { eq } from "drizzle-orm";
+import { paths } from "@/lib/config";
 import { postDetailsTwitter, posts, twitterUsers } from "@/lib/db/schema";
 import type { IMetadataProcessor } from "@/lib/library/processors/base";
 import type { ProcessorContext, ProcessTask } from "@/lib/library/types";
@@ -119,7 +120,7 @@ export class TwitterProcessor implements IMetadataProcessor<TwitterMeta> {
             url: `https://x.com/${userObj.name || userObj.nick || "i"}/status/${tid}`,
             metadataPath: task.jsonPath
               ? path
-                  .relative(path.join(process.cwd(), "public"), task.jsonPath)
+                  .relative(path.dirname(paths.downloads), task.jsonPath)
                   .split(path.sep)
                   .join("/")
               : null,
@@ -172,7 +173,7 @@ export class TwitterProcessor implements IMetadataProcessor<TwitterMeta> {
           }
           if (task.jsonPath) {
             updateSet.metadataPath = path
-              .relative(path.join(process.cwd(), "public"), task.jsonPath)
+              .relative(path.dirname(paths.downloads), task.jsonPath)
               .split(path.sep)
               .join("/");
           }

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -750,7 +750,10 @@ async function processItem(
       .replace(/^\//, "")
       .split("/")
       .join(path.sep);
-    const absLookupPath = path.join(process.cwd(), "public", cleanRelPath);
+    const absLookupPath = path.join(
+      path.dirname(paths.downloads),
+      cleanRelPath,
+    );
     internalSourceId = sourceMap.get(absLookupPath) ?? null;
   }
 
@@ -828,7 +831,10 @@ async function processItem(
               title: title || null,
               content: content || null,
               metadataPath: task.jsonPath
-                ? task.jsonPath.substring(paths.dataDir.length)
+                ? path
+                    .relative(path.dirname(paths.downloads), task.jsonPath)
+                    .split(path.sep)
+                    .join("/")
                 : null,
               createdAt: new Date(),
             })

--- a/src/lib/scrapers/runner.ts
+++ b/src/lib/scrapers/runner.ts
@@ -42,9 +42,34 @@ export class ScraperRunner {
       "gallery-dl-default.conf",
     );
 
+    let resolvedDefaultConfigPath = defaultConfigPath;
+    if (!fs.existsSync(defaultConfigPath)) {
+      const pathsToTry = [
+        path.join(__dirname, "..", "..", "..", "gallery-dl-default.conf"),
+        path.join(__dirname, "..", "..", "..", "..", "gallery-dl-default.conf"),
+        path.join(
+          __dirname,
+          "..",
+          "..",
+          "..",
+          "..",
+          "..",
+          "gallery-dl-default.conf",
+        ),
+        "/snapshot/web-gallery/gallery-dl-default.conf",
+        "/snapshot/web-gallery/.next/standalone/gallery-dl-default.conf",
+      ];
+      for (const p of pathsToTry) {
+        if (fs.existsSync(p)) {
+          resolvedDefaultConfigPath = p;
+          break;
+        }
+      }
+    }
+
     if (!fs.existsSync(configPath)) {
-      if (fs.existsSync(defaultConfigPath)) {
-        fs.copyFileSync(defaultConfigPath, configPath);
+      if (fs.existsSync(resolvedDefaultConfigPath)) {
+        fs.copyFileSync(resolvedDefaultConfigPath, configPath);
       } else {
         console.warn(
           "Warning: gallery-dl-default.conf not found. Skipping default config creation.",
@@ -73,7 +98,17 @@ export class ScraperRunner {
     const args = strategy.buildArgs();
     console.log(`Starting ${tool} with args:`, args);
 
-    const child = spawn(tool, args, {
+    const getCommandPath = (command: string): string => {
+      const localBin = path.join(
+        process.cwd(),
+        "bin",
+        process.platform === "win32" ? `${command}.exe` : command,
+      );
+      return fs.existsSync(localBin) ? localBin : command;
+    };
+
+    const cmdPath = getCommandPath(tool);
+    const child = spawn(cmdPath, args, {
       shell: false,
       cwd: process.cwd(),
     });

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -131,6 +131,30 @@ export async function saveSettings(settings: SystemSettings): Promise<void> {
   // 2. Update gallery-dl.conf
   const configPath = paths.galleryDl.config;
   const defaultConfigPath = path.join(process.cwd(), "gallery-dl-default.conf");
+  let resolvedDefaultConfigPath = defaultConfigPath;
+  if (!existsSync(defaultConfigPath)) {
+    const pathsToTry = [
+      path.join(__dirname, "..", "..", "..", "gallery-dl-default.conf"),
+      path.join(__dirname, "..", "..", "..", "..", "gallery-dl-default.conf"),
+      path.join(
+        __dirname,
+        "..",
+        "..",
+        "..",
+        "..",
+        "..",
+        "gallery-dl-default.conf",
+      ),
+      "/snapshot/web-gallery/gallery-dl-default.conf",
+      "/snapshot/web-gallery/.next/standalone/gallery-dl-default.conf",
+    ];
+    for (const p of pathsToTry) {
+      if (existsSync(p)) {
+        resolvedDefaultConfigPath = p;
+        break;
+      }
+    }
+  }
 
   let configJson: Record<string, unknown> = {};
 
@@ -149,10 +173,13 @@ export async function saveSettings(settings: SystemSettings): Promise<void> {
   }
 
   // If config is empty, read from default template first
-  if (Object.keys(configJson).length === 0 && existsSync(defaultConfigPath)) {
+  if (
+    Object.keys(configJson).length === 0 &&
+    existsSync(resolvedDefaultConfigPath)
+  ) {
     try {
       configJson = JSON.parse(
-        await fs.readFile(defaultConfigPath, "utf-8"),
+        await fs.readFile(resolvedDefaultConfigPath, "utf-8"),
       ) as Record<string, unknown>;
     } catch (e) {
       console.error("[Settings] Could not parse default template config:", e);

--- a/src/lib/utils/media-dimensions.ts
+++ b/src/lib/utils/media-dimensions.ts
@@ -1,14 +1,25 @@
 import { execFile } from "node:child_process";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
+import path from "node:path";
 import { promisify } from "node:util";
 
 const execFileAsync = promisify(execFile);
+
+function getCommandPath(command: string): string {
+  const localBin = path.join(
+    process.cwd(),
+    "bin",
+    process.platform === "win32" ? `${command}.exe` : command,
+  );
+  return fsSync.existsSync(localBin) ? localBin : command;
+}
 
 async function getVideoDimensions(
   filePath: string,
 ): Promise<{ width: number; height: number } | null> {
   try {
-    const { stdout } = await execFileAsync("ffprobe", [
+    const { stdout } = await execFileAsync(getCommandPath("ffprobe"), [
       "-v",
       "error",
       "-select_streams",

--- a/tests/gallery.spec.ts
+++ b/tests/gallery.spec.ts
@@ -126,12 +126,16 @@ test("gallery column controls change column counts", async ({ page }) => {
   await expect(page.getByTestId("loading-skeleton")).toBeHidden();
 
   // Find the column count label
-  const label = page.locator("span", { hasText: /Columns:/ });
+  const label = page.locator("span", { hasText: /Columns:/ }).first();
   await expect(label).toBeVisible();
 
   // Find and click "Decrease Columns" button
-  const decreaseBtn = page.getByRole("button", { name: "Decrease Columns" });
-  const increaseBtn = page.getByRole("button", { name: "Increase Columns" });
+  const decreaseBtn = page
+    .getByRole("button", { name: "Decrease Columns" })
+    .first();
+  const increaseBtn = page
+    .getByRole("button", { name: "Increase Columns" })
+    .first();
 
   await expect(decreaseBtn).toBeVisible();
   await expect(increaseBtn).toBeVisible();


### PR DESCRIPTION
# Standalone Release Packaging Walkthrough

We have successfully packaged **Web Gallery** into standalone executable binaries for Linux, macOS, and Windows. This was achieved by setting up an automated release compilation pipeline using `@yao-pkg/pkg` (Single Executable Application Mode), implementing virtual filesystem (VFS) runtime patches, refactoring file path structures, and providing installers for portable external dependencies.

---

## Changes Made

### 1. Build and Release Infrastructure
- **Release Build Pipeline**: Created [scripts/build-release.js](file:///home/darkkal/Source/Remote/Github/web-gallery/scripts/build-release.js) to automate:
  - Building the Next.js standalone application (`npm run build`).
  - Merging `.next/static` assets, dynamic `public` directories (excluding local storage volumes), and Drizzle database migration scripts.
  - Patching Next.js's `server.js` and Turbopack runtimes for Virtual File System compatibility.
  - Packaging the final distribution folders into executable binaries via `pkg`.
  - Copying automated platform dependency setup scripts to the final `dist/` folder.
- **Dependency Setup Scripts**: Created installers to automate downloading and placing platform-specific executables (`gallery-dl`, `ffmpeg`, `ffprobe`) in `./bin/`:
  - [scripts/setup-deps.sh](file:///home/darkkal/Source/Remote/Github/web-gallery/scripts/setup-deps.sh) (Linux / macOS)
  - [scripts/setup-deps.ps1](file:///home/darkkal/Source/Remote/Github/web-gallery/scripts/setup-deps.ps1) (Windows)
- **Configuration metadata**:
  - Updated [package.json](file:///home/darkkal/Source/Remote/Github/web-gallery/package.json) to declare `server.js` as the binary entry point, configure target platforms (`node22-linux-x64`, `node22-macos-x64`, `node22-win-x64`), bundle assets (`.next/**/*`, `public/**/*`, `drizzle/**/*`, `gallery-dl-default.conf`, `node_modules/**/*`), and added the `build:release` script.
  - Modified [next.config.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/next.config.ts) to define `outputFileTracingExcludes` to prevent developer env files, E2E tests, and release caches from being traced and bundled.
  - Updated [.gitignore](file:///home/darkkal/Source/Remote/Github/web-gallery/.gitignore) and [.dockerignore](file:///home/darkkal/Source/Remote/Github/web-gallery/.dockerignore) to ignore the `dist/` directory, `./downloads/`, and `./avatars/` folders.
- **GitHub Actions Release Automation**: Updated [.github/workflows/release.yml](file:///home/darkkal/Source/Remote/Github/web-gallery/.github/workflows/release.yml) to automatically build the standalone binaries when a release is triggered, package them along with their installer scripts into `.tar.gz` and `.zip` archives, and upload them as assets directly to the GitHub release.

### 2. Standalone Server Patches and VFS Fixes
- **`.env` Config File Support**: Patched `server.js` to search for and parse a local `.env` configuration file in the current working directory at early boot. This allows users to configure `PORT`, `HOSTNAME`, `DATA_DIR`, and `MEDIA_DIR` before ports are resolved.
- **Browser Auto-Open & Host Logging**: Configured `server.js` to wait for the Next.js listening promise, log the resolved host URL to the console, and invoke platform-specific tools (`open`, `start`, or `xdg-open`) to automatically display the interface in the system's default browser.
- **Turbopack Webpack Compatibility**: Modified the ESM dynamic import loader (`externalImport`) recursively within compiled standalone server chunks. If an ESM load fails inside the compiled snapshot, it catches the exception and falls back to a CommonJS `require(id)`.
- **Module Safeguards**: Mocked the Node `inspector` module (which is missing in `pkg` base binaries) to prevent runtime crashes, and redirected hashed libsql imports (`@libsql/client-[hash]`) to the standard `@libsql/client` module.

### 3. Path Refactoring & Persistent Storage Defaults
- **Portable Folder Defaults**: Modified [src/lib/config.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/config.ts) to set the default storage directories to `./data` and `./downloads` in the execution root if no environment variables are defined.
- **Auto-Directory Initialization**:
  - Configured [src/lib/db/index.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/index.ts) to check and build the parent directory of `sqlite.db` (usually `./data`) at import time to prevent static generation worker crashes on clean environments.
  - Updated [src/instrumentation.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/instrumentation.ts) to ensure local directories (`./data`, `./downloads`, `./avatars`) exist dynamically at startup.
- **Asset Routing Refactoring**: Updated [src/lib/db/repositories/media.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/repositories/media.ts), [src/lib/library/scanner.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/scanner.ts), and the Gelbooru, Pixiv, and Twitter metadata processors ([src/lib/library/processors/gelbooru.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/gelbooru.ts), [pixiv.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/pixiv.ts), [twitter.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/twitter.ts)) to reference files relative to `path.dirname(paths.downloads)` instead of a hardcoded `/public` path.
- **VFS Migrations and Config Lookups**: Configured database migrations in [src/lib/db/index.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/index.ts) and config template checks in [src/lib/settings.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/settings.ts) and [src/lib/scrapers/runner.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/scrapers/runner.ts) to look inside dynamic `/snapshot/` VFS paths if the directories are not present in the host system.

### 4. Portable External Dependencies Setup
- **Local Binary Search Precedence**: Modified scraper running processes in [src/lib/scrapers/runner.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/scrapers/runner.ts) and media analyzer utilities in [src/lib/utils/media-dimensions.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/utils/media-dimensions.ts) to look for executable files inside `./bin/` first before defaulting to the system environment path.

### 5. Dockerfile and Testing Adjustments
- **Turbopack next-server Fix**: Updated [Dockerfile](file:///home/darkkal/Source/Remote/Github/web-gallery/Dockerfile) to explicitly copy the compiled `next-server` module dependencies from `node_modules` into the standalone image context, matching the build-release patch and fixing container runtime issues.
- **E2E Layout Compatibility**: Patched decreased/increased column locators in [tests/gallery.spec.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/tests/gallery.spec.ts) using `.first()` to resolve column control selector collisions in mobile viewport tests.

---

## What Was Tested

1. **Automated compilation validation**:
   - Executed `npm run build:release` to verify compilation and SEA bundling pipeline success. Checked that the binaries `web-gallery-linux`, `web-gallery-macos`, and `web-gallery-win.exe` were successfully generated inside `dist/` with setup scripts.
2. **Local dependency installers**:
   - Ran `scripts/setup-deps.sh` and verified that local `gallery-dl`, `ffmpeg`, and `ffprobe` binaries were correctly retrieved, extracted, and placed inside the local `./bin` directory.
3. **Execution, Logging, and Auto-Open**:
   - Executed `PORT=3018 ./web-gallery-linux` on the host machine. Confirmed that directories `./data/`, `./downloads/`, and `./avatars/` were initialized, and console logs successfully outputted the host URL and triggered browser launch.
4. **Environment File Loading**:
   - Placed a `.env` file containing `PORT=3019` in the same directory as the executable. Started the binary, and verified it successfully read the file and ran on port `3019`.
5. **E2E Test Suites**:
   - Executed `npm run test:e2e` inside the test container setup on an alternative port (avoiding the user's running production environment). Verified all 122 integration tests passed.

---

## Validation Results

- **Release Artifacts generated in `dist/`**:
  - `web-gallery-linux` (Linux executable binary): **497 MB**
  - `web-gallery-macos` (macOS executable binary): **485 MB**
  - `web-gallery-win.exe` (Windows executable binary): **480 MB**
  - `setup-deps.sh` (Linux/macOS dependencies installer)
  - `setup-deps.ps1` (Windows dependencies installer)
- **E2E Integration Verification**: **122 tests passed** (0 failures).
