### PR TITLE
51 allow user to add tags to a post

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -122,7 +122,8 @@ web-gallery/
 │   │   ├── ThemeProvider.tsx       #   Dark/light theme via data-theme attribute
 │   │   ├── FormattedContent.tsx    #   Renders post body (links, hashtags, mentions)
 │   │   ├── InfiniteScrollSentinel.tsx # IntersectionObserver-based infinite scroll trigger
-│   │   └── AddToPlaylistModal.tsx  #   Modal to add media items to a playlist
+│   │   ├── AddToPlaylistModal.tsx  #   Modal to add media items to a playlist
+│   │   └── TagAutocompleteInput.tsx #  Input with autocomplete suggestions for tags
 │   ├── hooks/                      # Shared custom React hooks
 │   │   ├── useAutoplayVideo.ts     #   IntersectionObserver-based video autoplay
 │   │   ├── useDebouncedValue.ts    #   Debounce for search/sort inputs
@@ -313,7 +314,8 @@ src/app/gallery/
 ├── components/           # Sub-components (pure rendering)
 │   ├── FilterBar.tsx
 │   ├── GalleryItem.tsx
-│   └── BulkActionBar.tsx
+│   ├── BulkActionBar.tsx
+│   └── BulkTagPopover.tsx    #   Popover for bulk tagging selected gallery items
 └── page.module.css       # Shared CSS for this page and all sub-components
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,7 @@ src/app/actions/
 ├── scanning.ts   # Library scan control
 ├── settings.ts   # Settings updates & config sync
 ├── sources.ts    # Source CRUD
-├── tags.ts       # Tag queries
+├── tags.ts       # Tag queries and mutations
 └── timeline.ts   # Timeline mutations
 ```
 

--- a/src/app/actions/tags.ts
+++ b/src/app/actions/tags.ts
@@ -3,6 +3,8 @@
 import { count, desc, eq, isNull, sql } from "drizzle-orm";
 import { db } from "@/lib/db";
 import * as postsRepo from "@/lib/db/repositories/posts";
+import { incrementStatistics } from "@/lib/db/repositories/statistics";
+import * as tagsRepo from "@/lib/db/repositories/tags";
 import { posts, postTags, tags } from "@/lib/db/schema";
 
 export async function getPostTags(postId: number) {
@@ -65,4 +67,50 @@ export async function getTopTags(
     .limit(100);
 
   return results;
+}
+
+export async function addTagToPost(postId: number, tagName: string) {
+  const trimmed = tagName.trim();
+  if (!trimmed) {
+    throw new Error("Tag name cannot be empty");
+  }
+  if (trimmed.length > 200) {
+    throw new Error("Tag name cannot exceed 200 characters");
+  }
+
+  const { tag, isNew } = await tagsRepo.createOrFindTag(trimmed);
+  await tagsRepo.linkTagToPost(tag.id, postId);
+
+  if (isNew) {
+    await incrementStatistics({ totalTags: 1 });
+  }
+
+  return tag;
+}
+
+export async function removeTagFromPost(postId: number, tagId: number) {
+  const unlinked = await tagsRepo.unlinkTagFromPost(tagId, postId);
+  return unlinked;
+}
+
+export async function bulkAddTagToPosts(postIds: number[], tagName: string) {
+  const trimmed = tagName.trim();
+  if (!trimmed) {
+    throw new Error("Tag name cannot be empty");
+  }
+  if (trimmed.length > 200) {
+    throw new Error("Tag name cannot exceed 200 characters");
+  }
+  if (postIds.length === 0) {
+    return { tag: null, linkedCount: 0 };
+  }
+
+  const { tag, isNew } = await tagsRepo.createOrFindTag(trimmed);
+  const linkedCount = await tagsRepo.bulkLinkTagToPosts(tag.id, postIds);
+
+  if (isNew) {
+    await incrementStatistics({ totalTags: 1 });
+  }
+
+  return { tag, linkedCount };
 }

--- a/src/app/gallery/components/BulkActionBar.tsx
+++ b/src/app/gallery/components/BulkActionBar.tsx
@@ -6,6 +6,7 @@ interface BulkActionBarProps {
   selectedCount: number;
   onBulkDelete: (deleteFiles: boolean) => void;
   onAddToPlaylist: () => void;
+  onAddTags: () => void;
   onBulkRefetch: () => void;
   deleting: boolean;
   refetching: boolean;
@@ -15,6 +16,7 @@ export default function BulkActionBar({
   selectedCount,
   onBulkDelete,
   onAddToPlaylist,
+  onAddTags,
   onBulkRefetch,
   deleting,
   refetching,
@@ -32,6 +34,14 @@ export default function BulkActionBar({
           disabled={deleting || refetching}
         >
           {refetching ? "Refetching..." : "Refetch Post Data"}
+        </button>
+        <button
+          type="button"
+          className={styles.playlistButton}
+          onClick={onAddTags}
+          disabled={deleting || refetching}
+        >
+          Add Tags
         </button>
         <button
           type="button"

--- a/src/app/gallery/components/BulkTagPopover.tsx
+++ b/src/app/gallery/components/BulkTagPopover.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { bulkAddTagToPosts } from "@/app/actions/tags";
+import TagAutocompleteInput from "@/components/TagAutocompleteInput";
+import styles from "../page.module.css";
+
+interface BulkTagPopoverProps {
+  isOpen: boolean;
+  onClose: () => void;
+  postIds: number[];
+  onComplete: () => void;
+}
+
+export default function BulkTagPopover({
+  isOpen,
+  onClose,
+  postIds,
+  onComplete,
+}: BulkTagPopoverProps) {
+  const [stagedTags, setStagedTags] = useState<string[]>([]);
+  const [isApplying, setIsApplying] = useState(false);
+  const [progressText, setProgressText] = useState("");
+  const popoverRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setStagedTags([]);
+      setIsApplying(false);
+      setProgressText("");
+    }
+  }, [isOpen]);
+
+  // Click outside to close
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        popoverRef.current &&
+        !popoverRef.current.contains(event.target as Node)
+      ) {
+        onClose();
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, [isOpen, onClose]);
+
+  // Escape key to close
+  useEffect(() => {
+    if (!isOpen) return;
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      }
+    }
+    window.addEventListener("keydown", handleKeyDown);
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleAddStagedTag = (tagName: string) => {
+    const trimmed = tagName.trim();
+    if (
+      trimmed &&
+      !stagedTags.some((t) => t.toLowerCase() === trimmed.toLowerCase())
+    ) {
+      setStagedTags((prev) => [...prev, trimmed]);
+    }
+  };
+
+  const handleRemoveStagedTag = (tagName: string) => {
+    setStagedTags((prev) => prev.filter((t) => t !== tagName));
+  };
+
+  const handleApply = async () => {
+    if (stagedTags.length === 0 || postIds.length === 0) return;
+    setIsApplying(true);
+
+    try {
+      for (let i = 0; i < stagedTags.length; i++) {
+        const tag = stagedTags[i];
+        setProgressText(`Applying "${tag}" (${i + 1}/${stagedTags.length})...`);
+        await bulkAddTagToPosts(postIds, tag);
+      }
+      onComplete();
+    } catch (err) {
+      alert(`Error applying tags: ${err}`);
+    } finally {
+      setIsApplying(false);
+      setProgressText("");
+    }
+  };
+
+  return (
+    <div className={styles.bulkTagPopoverWrapper}>
+      <div ref={popoverRef} className={styles.bulkTagPopover}>
+        <h4 className={styles.bulkTagTitle}>Add Tags to Selection</h4>
+
+        {postIds.length === 0 ? (
+          <p className={styles.bulkTagWarning}>No posts are selected.</p>
+        ) : (
+          <>
+            <div className={styles.bulkTagInputContainer}>
+              <TagAutocompleteInput
+                onTagSelected={handleAddStagedTag}
+                placeholder="Search or enter tag name..."
+                excludeTags={stagedTags}
+                disabled={isApplying}
+              />
+            </div>
+
+            {stagedTags.length > 0 && (
+              <div className={styles.stagedTagChips}>
+                {stagedTags.map((tag) => (
+                  <span key={tag} className={styles.stagedTagChip}>
+                    #{tag}
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveStagedTag(tag)}
+                      className={styles.stagedTagRemoveBtn}
+                      disabled={isApplying}
+                      aria-label={`Remove staged tag ${tag}`}
+                    >
+                      ✕
+                    </button>
+                  </span>
+                ))}
+              </div>
+            )}
+
+            {isApplying && (
+              <div className={styles.progressText}>{progressText}</div>
+            )}
+
+            <div className={styles.bulkTagPopoverFooter}>
+              <button
+                type="button"
+                className={styles.cancelTagsBtn}
+                onClick={onClose}
+                disabled={isApplying}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.applyTagsBtn}
+                onClick={handleApply}
+                disabled={isApplying || stagedTags.length === 0}
+              >
+                {isApplying
+                  ? "Applying..."
+                  : `Apply to ${postIds.length} Posts`}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/gallery/page-client.tsx
+++ b/src/app/gallery/page-client.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { deleteMediaItems, refetchPostData } from "@/app/actions/gallery";
 import BulkActionBar from "@/app/gallery/components/BulkActionBar";
+import BulkTagPopover from "@/app/gallery/components/BulkTagPopover";
 import FilterBar from "@/app/gallery/components/FilterBar";
 import GalleryItem from "@/app/gallery/components/GalleryItem";
 import styles from "@/app/gallery/page.module.css";
@@ -88,6 +89,7 @@ function GalleryPageContent({
   const [deleting, setDeleting] = useState(false);
   const [refetching, setRefetching] = useState(false);
   const [isAddToPlaylistOpen, setIsAddToPlaylistOpen] = useState(false);
+  const [isBulkTagOpen, setIsBulkTagOpen] = useState(false);
 
   const [suppressSearch, setSuppressSearch] = useState(false);
 
@@ -123,6 +125,18 @@ function GalleryPageContent({
     clearSelection,
     selectedCount,
   } = useSelection();
+
+  const handleBulkTagPostIds = useMemo(() => {
+    const ids = new Set<number>();
+    for (const group of items) {
+      for (const gi of group.groupItems) {
+        if (selectedIds.has(gi.item.id) && gi.post?.id) {
+          ids.add(gi.post.id);
+        }
+      }
+    }
+    return Array.from(ids);
+  }, [selectedIds, items]);
 
   const {
     selectedIndex,
@@ -235,6 +249,7 @@ function GalleryPageContent({
           selectedCount={selectedCount}
           onBulkDelete={handleBulkDelete}
           onAddToPlaylist={() => setIsAddToPlaylistOpen(true)}
+          onAddTags={() => setIsBulkTagOpen(true)}
           onBulkRefetch={handleBulkRefetch}
           deleting={deleting}
           refetching={refetching}
@@ -364,6 +379,20 @@ function GalleryPageContent({
           clearSelection();
         }}
         mediaItemIds={Array.from(selectedIds)}
+      />
+
+      <BulkTagPopover
+        isOpen={isBulkTagOpen}
+        onClose={() => {
+          setIsBulkTagOpen(false);
+          clearSelection();
+        }}
+        postIds={handleBulkTagPostIds}
+        onComplete={async () => {
+          setIsBulkTagOpen(false);
+          clearSelection();
+          await refresh();
+        }}
       />
     </div>
   );

--- a/src/app/gallery/page.module.css
+++ b/src/app/gallery/page.module.css
@@ -393,3 +393,145 @@
   gap: 4px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.3);
 }
+
+.bulkTagPopoverWrapper {
+  position: fixed;
+  bottom: 5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 1000;
+  animation: slideUp 0.2s ease-out;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translate(-50%, 20px);
+    opacity: 0;
+  }
+  to {
+    transform: translate(-50%, 0);
+    opacity: 1;
+  }
+}
+
+.bulkTagPopover {
+  background: hsl(var(--card));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  padding: 1.25rem;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  width: 380px;
+  max-width: 90vw;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.bulkTagTitle {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: hsl(var(--foreground));
+}
+
+.bulkTagWarning {
+  margin: 0;
+  font-size: 0.875rem;
+  color: hsl(var(--color-danger));
+}
+
+.bulkTagInputContainer {
+  position: relative;
+  width: 100%;
+}
+
+.stagedTagChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  max-height: 80px;
+  overflow-y: auto;
+  padding: 2px;
+}
+
+.stagedTagChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: hsl(var(--secondary));
+  color: hsl(var(--foreground));
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  border-radius: 9999px;
+  border: 1px solid hsl(var(--border));
+}
+
+.stagedTagRemoveBtn {
+  background: transparent;
+  border: none;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  padding: 0;
+  font-size: 0.75rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 12px;
+  height: 12px;
+}
+
+.stagedTagRemoveBtn:hover {
+  color: hsl(var(--color-danger));
+}
+
+.progressText {
+  font-size: 0.825rem;
+  color: hsl(var(--color-info));
+  font-style: italic;
+}
+
+.bulkTagPopoverFooter {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 0.5rem;
+}
+
+.cancelTagsBtn {
+  background: transparent;
+  border: 1px solid hsl(var(--border));
+  color: hsl(var(--foreground));
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.cancelTagsBtn:hover {
+  background: hsl(var(--secondary));
+}
+
+.applyTagsBtn {
+  background: hsl(var(--primary));
+  color: hsl(var(--primary-foreground));
+  border: none;
+  padding: 0.5rem 1rem;
+  font-size: 0.875rem;
+  font-weight: 600;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: opacity 0.15s;
+}
+
+.applyTagsBtn:hover:not(:disabled) {
+  opacity: 0.9;
+}
+
+.applyTagsBtn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/src/components/Lightbox.module.css
+++ b/src/components/Lightbox.module.css
@@ -583,3 +583,79 @@
   animation: spin 0.8s linear infinite;
   display: inline-block;
 }
+
+.tagChipEditable {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: hsl(var(--secondary) / 0.6);
+  color: hsl(var(--foreground));
+  font-size: 0.75rem;
+  font-weight: 500;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius);
+  border: 1px solid hsl(var(--border) / 0.5);
+  transition:
+    background-color 0.15s,
+    border-color 0.15s;
+}
+
+.tagChipEditable:hover {
+  background: hsl(var(--secondary));
+  border-color: hsl(var(--border));
+}
+
+.tagName {
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tagRemoveBtn {
+  background: none;
+  border: none;
+  color: hsl(var(--muted-foreground));
+  cursor: pointer;
+  padding: 0 2px;
+  font-size: 0.75rem;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 0.1s;
+  border-radius: 2px;
+}
+
+.tagRemoveBtn:hover {
+  color: hsl(var(--color-danger));
+  background: hsl(var(--color-danger) / 0.1);
+}
+
+.tagAddSection {
+  margin-top: 12px;
+}
+
+.tagInputWrapper {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+}
+
+.tagCancelBtn {
+  background: transparent;
+  border: 1px solid hsl(var(--border));
+  color: hsl(var(--muted-foreground));
+  padding: 0.5rem 0.75rem;
+  font-size: 0.825rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+  transition: all 0.2s;
+  font-weight: 500;
+}
+
+.tagCancelBtn:hover {
+  background: hsl(var(--accent));
+  color: hsl(var(--foreground));
+}

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -4,10 +4,15 @@ import Image from "next/image";
 import Link from "next/link";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { getPlaylistsForMediaItem } from "@/app/actions/playlists";
-import { getPostTags } from "@/app/actions/tags";
+import {
+  addTagToPost,
+  getPostTags,
+  removeTagFromPost,
+} from "@/app/actions/tags";
 import AddToPlaylistModal from "@/components/AddToPlaylistModal";
 import FormattedContent from "@/components/FormattedContent";
 import styles from "@/components/Lightbox.module.css";
+import TagAutocompleteInput from "@/components/TagAutocompleteInput";
 import type {
   UnifiedGelbooruv02Data,
   UnifiedPixivData,
@@ -52,8 +57,35 @@ export default function Lightbox({
 }: LightboxProps) {
   const { item } = row;
   const [showInfo, setShowInfo] = useState(true);
-  const [pixivTags, setPixivTags] = useState<{ name: string }[]>([]);
+  const [postTags, setPostTags] = useState<{ id: number; name: string }[]>([]);
+  const [isAddingTag, setIsAddingTag] = useState(false);
   const [isRecentlyMounted, setIsRecentlyMounted] = useState(true);
+
+  async function handleAddTag(tagName: string) {
+    if (!row.post?.id) return;
+    try {
+      const newTag = await addTagToPost(row.post.id, tagName);
+      setPostTags((prev) => {
+        if (prev.some((t) => t.id === newTag.id)) return prev;
+        return [...prev, newTag];
+      });
+      setIsAddingTag(false);
+    } catch (err) {
+      alert(`Failed to add tag: ${err}`);
+    }
+  }
+
+  async function handleRemoveTag(tagId: number) {
+    if (!row.post?.id) return;
+    try {
+      const success = await removeTagFromPost(row.post.id, tagId);
+      if (success) {
+        setPostTags((prev) => prev.filter((t) => t.id !== tagId));
+      }
+    } catch (err) {
+      alert(`Failed to remove tag: ${err}`);
+    }
+  }
   const [refetching, setRefetching] = useState(false);
   const videoRef = useRef<HTMLVideoElement>(null);
 
@@ -152,19 +184,14 @@ export default function Lightbox({
     };
   }, []);
 
-  // Fetch Pixiv Tags
+  // Fetch Post Tags
   useEffect(() => {
-    if (pixiv?.id) {
-      getPostTags(pixiv.id).then(setPixivTags).catch(console.error);
+    if (row.post?.id) {
+      getPostTags(row.post.id).then(setPostTags).catch(console.error);
     } else {
-      // eslint-disable-next-line
-      setPixivTags([]);
+      setPostTags([]);
     }
-  }, [pixiv?.id]);
-
-  const tags = gelbooru?.tags
-    ? gelbooru.tags.map((tag) => ({ name: tag, id: 0 }))
-    : pixivTags;
+  }, [row.post?.id]);
 
   // Handle video playback errors
   useEffect(() => {
@@ -614,22 +641,55 @@ export default function Lightbox({
           </div>
         )}
 
-        {tags.length > 0 && (
-          <div className={styles.section}>
-            <h3 className={styles.sectionTitle}>Tags</h3>
+        <div className={styles.section}>
+          <h3 className={styles.sectionTitle}>Tags</h3>
+          {postTags.length === 0 ? (
+            <p className={styles.mutedText}>No tags</p>
+          ) : (
             <div className={styles.tagsContainer}>
-              {tags.map((tag, i) => (
-                <span
-                  // biome-ignore lint/suspicious/noArrayIndexKey: Stable sorted tags
-                  key={i}
-                  className={styles.tagChip}
-                >
-                  #{tag.name}
+              {postTags.map((tag) => (
+                <span key={tag.id} className={styles.tagChipEditable}>
+                  <span className={styles.tagName}>#{tag.name}</span>
+                  <button
+                    type="button"
+                    className={styles.tagRemoveBtn}
+                    onClick={() => handleRemoveTag(tag.id)}
+                    aria-label={`Remove tag ${tag.name}`}
+                  >
+                    ✕
+                  </button>
                 </span>
               ))}
             </div>
+          )}
+
+          <div className={styles.tagAddSection}>
+            {isAddingTag ? (
+              <div className={styles.tagInputWrapper}>
+                <TagAutocompleteInput
+                  onTagSelected={handleAddTag}
+                  placeholder="Enter tag name..."
+                  excludeTags={postTags.map((t) => t.name)}
+                />
+                <button
+                  type="button"
+                  className={styles.tagCancelBtn}
+                  onClick={() => setIsAddingTag(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            ) : (
+              <button
+                type="button"
+                className={styles.sidebarActionBtn}
+                onClick={() => setIsAddingTag(true)}
+              >
+                + Add Tag
+              </button>
+            )}
           </div>
-        )}
+        </div>
 
         {(row.post?.url || (tweet?.tweetId && user)) && (
           <div className={styles.section}>

--- a/src/components/TagAutocompleteInput.module.css
+++ b/src/components/TagAutocompleteInput.module.css
@@ -1,0 +1,94 @@
+.wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.inputContainer {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.input {
+  width: 100%;
+  padding: 0.5rem 2rem 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  background: hsl(var(--secondary) / 0.5);
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  color: hsl(var(--foreground));
+  outline: none;
+  transition:
+    border-color 0.15s,
+    background-color 0.15s;
+}
+
+.input:focus {
+  border-color: hsl(var(--primary));
+  background: hsl(var(--secondary));
+}
+
+.spinnerWrapper {
+  position: absolute;
+  right: 0.75rem;
+  display: flex;
+  align-items: center;
+  color: hsl(var(--muted-foreground));
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  z-index: 50;
+  margin-top: 4px;
+  background: hsl(var(--popover));
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.dropdownItem {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.5rem 0.75rem;
+  cursor: pointer;
+  font-size: 0.875rem;
+  transition: background-color 0.1s;
+}
+
+.dropdownItem[data-active="true"],
+.dropdownItem:hover {
+  background: hsl(var(--accent));
+}
+
+.tagLabel {
+  font-weight: 500;
+  color: hsl(var(--foreground));
+}
+
+.tagCount {
+  font-size: 0.75rem;
+  color: hsl(var(--muted-foreground));
+  background: hsl(var(--secondary));
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+}

--- a/src/components/TagAutocompleteInput.tsx
+++ b/src/components/TagAutocompleteInput.tsx
@@ -1,0 +1,206 @@
+import { Loader2 } from "lucide-react";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import { useDebouncedValue } from "@/hooks/useDebouncedValue";
+import type {
+  AutocompleteResponse,
+  AutocompleteSuggestion,
+} from "@/types/autocomplete";
+import styles from "./TagAutocompleteInput.module.css";
+
+interface TagAutocompleteInputProps {
+  onTagSelected: (tagName: string) => void;
+  placeholder?: string;
+  disabled?: boolean;
+  excludeTags?: string[];
+  className?: string;
+}
+
+export default function TagAutocompleteInput({
+  onTagSelected,
+  placeholder = "Add tag...",
+  disabled = false,
+  excludeTags = [],
+  className = "",
+}: TagAutocompleteInputProps) {
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const [suggestions, setSuggestions] = useState<AutocompleteSuggestion[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  // Focus input on mount
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  // Fetch suggestions when debouncedQuery changes
+  useEffect(() => {
+    let active = true;
+    if (debouncedQuery.trim().length < 2) {
+      setSuggestions([]);
+      setIsOpen(false);
+      setSelectedIndex(-1);
+      return;
+    }
+
+    async function fetchTags() {
+      setIsLoading(true);
+      try {
+        const res = await fetch(
+          `/api/autocomplete?column=tag&q=${encodeURIComponent(debouncedQuery.trim())}`,
+        );
+        if (!res.ok) throw new Error("Failed to fetch tags");
+        const data: AutocompleteResponse = await res.json();
+
+        if (active) {
+          // Filter out excluded tags (case-insensitive)
+          const filtered = data.suggestions.filter(
+            (s) =>
+              !excludeTags.some(
+                (ex) => ex.toLowerCase() === s.value.toLowerCase(),
+              ),
+          );
+          setSuggestions(filtered);
+          setIsOpen(filtered.length > 0);
+          setSelectedIndex(-1);
+        }
+      } catch (err) {
+        console.error(err);
+      } finally {
+        if (active) setIsLoading(false);
+      }
+    }
+
+    fetchTags();
+
+    return () => {
+      active = false;
+    };
+  }, [debouncedQuery, excludeTags]);
+
+  // Click outside to close
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(event.target as Node)
+      ) {
+        setIsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+    };
+  }, []);
+
+  const handleSelect = (tagName: string) => {
+    if (tagName.trim()) {
+      onTagSelected(tagName.trim());
+      setQuery("");
+      setSuggestions([]);
+      setIsOpen(false);
+      setSelectedIndex(-1);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Crucial: stop propagation to prevent lightbox from closing or shifting slides
+    e.stopPropagation();
+
+    if (e.key === "Escape") {
+      setIsOpen(false);
+      setSelectedIndex(-1);
+      inputRef.current?.blur();
+      return;
+    }
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      if (suggestions.length === 0) return;
+      setSelectedIndex((prev) => (prev + 1) % suggestions.length);
+      setIsOpen(true);
+      return;
+    }
+
+    if (e.key === "ArrowUp") {
+      e.preventDefault();
+      if (suggestions.length === 0) return;
+      setSelectedIndex(
+        (prev) => (prev - 1 + suggestions.length) % suggestions.length,
+      );
+      setIsOpen(true);
+      return;
+    }
+
+    if (e.key === "Enter") {
+      e.preventDefault();
+      if (selectedIndex >= 0 && selectedIndex < suggestions.length) {
+        handleSelect(suggestions[selectedIndex].value);
+      } else if (query.trim()) {
+        handleSelect(query);
+      }
+    }
+  };
+
+  return (
+    <div ref={containerRef} className={`${styles.wrapper} ${className}`}>
+      <div className={styles.inputContainer}>
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onKeyUp={(e) => e.stopPropagation()} // Stop keyup propagation as well
+          placeholder={placeholder}
+          disabled={disabled}
+          className={styles.input}
+        />
+        {isLoading && (
+          <div className={styles.spinnerWrapper}>
+            <Loader2 className={styles.spinner} size={16} />
+          </div>
+        )}
+      </div>
+
+      {isOpen && suggestions.length > 0 && (
+        <div className={styles.dropdown} role="listbox">
+          {suggestions.map((suggestion, index) => {
+            const isActive = index === selectedIndex;
+            return (
+              <div
+                key={suggestion.value}
+                className={styles.dropdownItem}
+                data-active={isActive}
+                onClick={() => handleSelect(suggestion.value)}
+                onKeyDown={(ev) => {
+                  if (ev.key === "Enter" || ev.key === " ") {
+                    ev.preventDefault();
+                    handleSelect(suggestion.value);
+                  }
+                }}
+                role="option"
+                aria-selected={isActive}
+                tabIndex={-1}
+              >
+                <span className={styles.tagLabel}>{suggestion.label}</span>
+                {suggestion.count !== undefined && (
+                  <span className={styles.tagCount}>
+                    {suggestion.count}{" "}
+                    {suggestion.count === 1 ? "post" : "posts"}
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/db/repositories/tags.ts
+++ b/src/lib/db/repositories/tags.ts
@@ -7,8 +7,14 @@ import { postTags, tags } from "@/lib/db/schema";
  */
 export async function createOrFindTag(
   name: string,
-): Promise<{ id: number; name: string }> {
-  await db.insert(tags).values({ name }).onConflictDoNothing();
+): Promise<{ tag: { id: number; name: string }; isNew: boolean }> {
+  const result = await db
+    .insert(tags)
+    .values({ name })
+    .onConflictDoNothing()
+    .returning();
+
+  const isNew = result.length > 0;
 
   const tag = await db.query.tags.findFirst({
     where: eq(tags.name, name),
@@ -18,7 +24,7 @@ export async function createOrFindTag(
     throw new Error(`Failed to find or create tag: ${name}`);
   }
 
-  return tag;
+  return { tag, isNew };
 }
 
 /**

--- a/src/lib/db/repositories/tags.ts
+++ b/src/lib/db/repositories/tags.ts
@@ -1,0 +1,79 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { postTags, tags } from "@/lib/db/schema";
+
+/**
+ * Inserts a tag if it doesn't exist, and returns the tag record (id and name).
+ */
+export async function createOrFindTag(
+  name: string,
+): Promise<{ id: number; name: string }> {
+  await db.insert(tags).values({ name }).onConflictDoNothing();
+
+  const tag = await db.query.tags.findFirst({
+    where: eq(tags.name, name),
+  });
+
+  if (!tag) {
+    throw new Error(`Failed to find or create tag: ${name}`);
+  }
+
+  return tag;
+}
+
+/**
+ * Links a tag to a post if not already linked.
+ * Returns true if a new link was created, false otherwise.
+ */
+export async function linkTagToPost(
+  tagId: number,
+  postId: number,
+): Promise<boolean> {
+  const result = await db
+    .insert(postTags)
+    .values({ tagId, postId })
+    .onConflictDoNothing()
+    .returning();
+
+  return result.length > 0;
+}
+
+/**
+ * Unlinks a tag from a post.
+ * Returns true if the link existed and was removed, false otherwise.
+ */
+export async function unlinkTagFromPost(
+  tagId: number,
+  postId: number,
+): Promise<boolean> {
+  const result = await db
+    .delete(postTags)
+    .where(and(eq(postTags.tagId, tagId), eq(postTags.postId, postId)))
+    .returning();
+
+  return result.length > 0;
+}
+
+/**
+ * Bulk links a tag to multiple posts.
+ * Returns the count of new links created.
+ */
+export async function bulkLinkTagToPosts(
+  tagId: number,
+  postIds: number[],
+): Promise<number> {
+  if (postIds.length === 0) return 0;
+
+  const insertRows = postIds.map((postId) => ({
+    tagId,
+    postId,
+  }));
+
+  const result = await db
+    .insert(postTags)
+    .values(insertRows)
+    .onConflictDoNothing()
+    .returning();
+
+  return result.length;
+}


### PR DESCRIPTION
# Walkthrough — Issue #51: Allow user to add tags to a post

This walkthrough details the changes made to enable manual tag management (adding, removing, and bulk-tagging) on posts.

## Changes Made

### 1. Database Layer — Tag Repository
- Created [tags.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/repositories/tags.ts) with operations for:
  - `createOrFindTag(name)` — Inserts new tags atomically (using `onConflictDoNothing()`) and returns the record indicating if it was newly created.
  - `linkTagToPost(tagId, postId)` — Adds many-to-many relationship rows in `post_tags` junction table.
  - `unlinkTagFromPost(tagId, postId)` — Deletes the relationship row from `post_tags`.
  - `bulkLinkTagToPosts(tagId, postIds)` — Atomically adds relation rows in batches for a selection of posts.

### 2. Backend — Server Actions
- Added three mutation actions in [actions/tags.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/actions/tags.ts):
  - `addTagToPost(postId, tagName)` — Validates parameters, finds/creates a tag, links it, and calls `incrementStatistics({ totalTags: 1 })` if it is a new tag.
  - `removeTagFromPost(postId, tagId)` — Deletes the relationship link.
  - `bulkAddTagToPosts(postIds, tagName)` — Handles batch validation, tag allocation, linking, and statistics.

### 3. Shared UI — Tag Autocomplete Component
- Created [TagAutocompleteInput.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/TagAutocompleteInput.tsx) and [TagAutocompleteInput.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/TagAutocompleteInput.module.css):
  - Renders a search input field that requests suggestions from `/api/autocomplete?column=tag&q=...`.
  - Debounces key inputs (300ms) and filters out tags that are already on the post (`excludeTags`).
  - Supports keyboard navigation (ArrowUp/ArrowDown to highlight, Enter to select, Escape to close).
  - Isolates keyboard events (`stopPropagation` on keydown/keyup) to prevent focused inputs from triggering parent page interactions (such as Lightbox navigation or close).

### 4. Lightbox — Single Post Tag Management
- Refactored [Lightbox.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.tsx):
  - Unified tag loading using `getPostTags(postId)` for all post types instead of relying on extractor-specific tags.
  - Always render the tags sidebar section, displaying a muted `"No tags"` indicator when empty.
  - Rendered tags as chips with small close (`✕`) buttons that call `removeTagFromPost`.
  - Added a `+ Add Tag` button that reveals `TagAutocompleteInput` inline.
- Updated [Lightbox.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/components/Lightbox.module.css) with CSS Module styles for editable tag chips, hover animations, cancel/add buttons, and inline layout inputs.

### 5. Gallery — Bulk Tagging
- Created [BulkTagPopover.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/components/BulkTagPopover.tsx) which imports styles from the parent `page.module.css` (conforming to repository guidelines).
  - Stages multiple tags before applying.
  - Displays a sequential apply progress spinner/text while dispatching bulk insertions.
  - Closes on clicking outside, Escape key, or clicking "Cancel".
- Modified [BulkActionBar.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/components/BulkActionBar.tsx) to render the "Add Tags" action button.
- Updated [page-client.tsx](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/page-client.tsx) to manage open/close popover state, resolve selected post IDs, and render `BulkTagPopover`.
- Appended popover, staged chip, progress text, and button transition styles in [page.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/gallery/page.module.css).

### 6. Documentation
- Documented tag mutations in [ARCHITECTURE.md](file:///home/darkkal/Source/Remote/Github/web-gallery/ARCHITECTURE.md) and [CONTRIBUTING.md](file:///home/darkkal/Source/Remote/Github/web-gallery/CONTRIBUTING.md).

---

## Verification & Validation Results

### 1. Build Verification
Verified that the application compiles and bundles successfully under production configuration using:
```bash
npm run build
```

### 2. Biome Format & Lint Checking
All modified and created files were verified using the project standard linter/formatter:
```bash
npx biome check --write
```
Ensured that all TypeScript definitions compile with no warnings or errors.
