### PR TITLE
perf(db): add foreign key indexes to improve query performance

### DIFF
--- a/drizzle/0011_minor_magik.sql
+++ b/drizzle/0011_minor_magik.sql
@@ -1,0 +1,12 @@
+CREATE INDEX `idx_media_items_post_id` ON `media_items` (`post_id`);--> statement-breakpoint
+CREATE INDEX `idx_playlist_items_playlist_id` ON `playlist_items` (`playlist_id`);--> statement-breakpoint
+CREATE INDEX `idx_playlist_items_media_item_id` ON `playlist_items` (`media_item_id`);--> statement-breakpoint
+CREATE INDEX `idx_post_details_gelbooruv02_post_id` ON `post_details_gelbooruv02` (`post_id`);--> statement-breakpoint
+CREATE INDEX `idx_post_details_pixiv_post_id` ON `post_details_pixiv` (`post_id`);--> statement-breakpoint
+CREATE INDEX `idx_post_details_twitter_post_id` ON `post_details_twitter` (`post_id`);--> statement-breakpoint
+CREATE INDEX `idx_post_tags_post_id` ON `post_tags` (`post_id`);--> statement-breakpoint
+CREATE INDEX `idx_posts_internal_source_id` ON `posts` (`internal_source_id`);--> statement-breakpoint
+CREATE INDEX `idx_scrape_history_source_id` ON `scrape_history` (`source_id`);--> statement-breakpoint
+CREATE INDEX `idx_scrape_history_task_id` ON `scrape_history` (`task_id`);--> statement-breakpoint
+CREATE INDEX `idx_scraper_download_logs_source_id` ON `scraper_download_logs` (`source_id`);--> statement-breakpoint
+CREATE INDEX `idx_scraping_tasks_source_id` ON `scraping_tasks` (`source_id`);

--- a/drizzle/meta/0011_snapshot.json
+++ b/drizzle/meta/0011_snapshot.json
@@ -1,0 +1,1656 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "58fffd85-cb96-4224-8fb5-f504adb1e1d9",
+  "prevId": "f776d45a-cc18-403b-a276-745ac9abcc96",
+  "tables": {
+    "gallerydl_extractor_types": {
+      "name": "gallerydl_extractor_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "library_statistics": {
+      "name": "library_statistics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_media_items": {
+          "name": "total_media_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tags": {
+          "name": "total_tags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_extractors": {
+          "name": "total_extractors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_items_post_id": {
+          "name": "idx_media_items_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_items_post_id_posts_id_fk": {
+          "name": "media_items_post_id_posts_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pixiv_users": {
+      "name": "pixiv_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_followed": {
+          "name": "is_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_accept_request": {
+          "name": "is_accept_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlist_items": {
+      "name": "playlist_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_playlist_items_playlist_id": {
+          "name": "idx_playlist_items_playlist_id",
+          "columns": ["playlist_id"],
+          "isUnique": false
+        },
+        "idx_playlist_items_media_item_id": {
+          "name": "idx_playlist_items_media_item_id",
+          "columns": ["media_item_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "playlist_items_playlist_id_playlists_id_fk": {
+          "name": "playlist_items_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_items_media_item_id_media_items_id_fk": {
+          "name": "playlist_items_media_item_id_media_items_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "media_items",
+          "columnsFrom": ["media_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_gelbooruv02": {
+      "name": "post_details_gelbooruv02",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "md5": {
+          "name": "md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_details_gelbooruv02_post_id": {
+          "name": "idx_post_details_gelbooruv02_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_details_gelbooruv02_post_id_posts_id_fk": {
+          "name": "post_details_gelbooruv02_post_id_posts_id_fk",
+          "tableFrom": "post_details_gelbooruv02",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_pixiv": {
+      "name": "post_details_pixiv",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restrict": {
+          "name": "restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x_restrict": {
+          "name": "x_restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sanity_level": {
+          "name": "sanity_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_view": {
+          "name": "total_view",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_bookmarks": {
+          "name": "total_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_bookmarked": {
+          "name": "is_bookmarked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_ai_type": {
+          "name": "illust_ai_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_book_style": {
+          "name": "illust_book_style",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_details_pixiv_post_id": {
+          "name": "idx_post_details_pixiv_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_details_pixiv_post_id_posts_id_fk": {
+          "name": "post_details_pixiv_post_id_posts_id_fk",
+          "tableFrom": "post_details_pixiv",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_twitter": {
+      "name": "post_details_twitter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retweet_id": {
+          "name": "retweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_id": {
+          "name": "reply_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive_flags": {
+          "name": "sensitive_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite_count": {
+          "name": "favorite_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_count": {
+          "name": "quote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retweet_count": {
+          "name": "retweet_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bookmark_count": {
+          "name": "bookmark_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_details_twitter_post_id": {
+          "name": "idx_post_details_twitter_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_details_twitter_post_id_posts_id_fk": {
+          "name": "post_details_twitter_post_id_posts_id_fk",
+          "tableFrom": "post_details_twitter",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_tags_post_id": {
+          "name": "idx_post_tags_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_tag_id_post_id_pk": {
+          "columns": ["tag_id", "post_id"],
+          "name": "post_tags_tag_id_post_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_source_id": {
+          "name": "json_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_source_id": {
+          "name": "internal_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_path": {
+          "name": "metadata_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_source_deleted": {
+          "name": "is_source_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_posts_internal_source_id": {
+          "name": "idx_posts_internal_source_id",
+          "columns": ["internal_source_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_internal_source_id_sources_id_fk": {
+          "name": "posts_internal_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["internal_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_history": {
+      "name": "scan_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_type": {
+          "name": "scan_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "files_processed": {
+          "name": "files_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_added": {
+          "name": "files_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_updated": {
+          "name": "files_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_deleted": {
+          "name": "files_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scrape_history": {
+      "name": "scrape_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_downloaded": {
+          "name": "files_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_processed": {
+          "name": "posts_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_speed": {
+          "name": "average_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_scrape_history_source_id": {
+          "name": "idx_scrape_history_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "idx_scrape_history_task_id": {
+          "name": "idx_scrape_history_task_id",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scrape_history_source_id_sources_id_fk": {
+          "name": "scrape_history_source_id_sources_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_history_task_id_scraping_tasks_id_fk": {
+          "name": "scrape_history_task_id_scraping_tasks_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "scraping_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraper_download_logs": {
+      "name": "scraper_download_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scraper_download_logs_file_path_unique": {
+          "name": "scraper_download_logs_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        },
+        "idx_scraper_download_logs_source_id": {
+          "name": "idx_scraper_download_logs_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scraper_download_logs_source_id_sources_id_fk": {
+          "name": "scraper_download_logs_source_id_sources_id_fk",
+          "tableFrom": "scraper_download_logs",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraping_tasks": {
+      "name": "scraping_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_options": {
+          "name": "download_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_scraping_tasks_source_id": {
+          "name": "idx_scraping_tasks_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scraping_tasks_source_id_sources_id_fk": {
+          "name": "scraping_tasks_source_id_sources_id_fk",
+          "tableFrom": "scraping_tasks",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sources_extractor_type_gallerydl_extractor_types_id_fk": {
+          "name": "sources_extractor_type_gallerydl_extractor_types_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "gallerydl_extractor_types",
+          "columnsFrom": ["extractor_type"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "statistics_history": {
+      "name": "statistics_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_type": {
+          "name": "date_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'import'"
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_media_items": {
+          "name": "total_media_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tags": {
+          "name": "total_tags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_extractors": {
+          "name": "total_extractors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_statistics_history_date": {
+          "name": "idx_statistics_history_date",
+          "columns": ["date", "date_type"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twitter_users": {
+      "name": "twitter_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nick": {
+          "name": "nick",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_banner": {
+          "name": "profile_banner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favourites_count": {
+          "name": "favourites_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "friends_count": {
+          "name": "friends_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listed_count": {
+          "name": "listed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_count": {
+          "name": "media_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "statuses_count": {
+          "name": "statuses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1780342473153,
       "tag": "0010_even_rage",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1781760250983,
+      "tag": "0011_minor_magik",
+      "breakpoints": true
     }
   ]
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,5 +1,6 @@
 import { relations } from "drizzle-orm";
 import {
+  index,
   integer,
   primaryKey,
   sqliteTable,
@@ -28,61 +29,82 @@ export const sources = sqliteTable("sources", {
   deletedAt: integer("deleted_at", { mode: "timestamp" }),
 });
 
-export const scraperDownloadLogs = sqliteTable("scraper_download_logs", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  sourceId: integer("source_id")
-    .references(() => sources.id, { onDelete: "cascade" })
-    .notNull(),
-  filePath: text("file_path").notNull().unique(), // Unique path to map back to source
-  createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
-    () => new Date(),
-  ),
-});
-
-export const scrapingTasks = sqliteTable("scraping_tasks", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  sourceId: integer("source_id")
-    .references(() => sources.id, { onDelete: "cascade" })
-    .notNull(),
-  name: text("name"),
-  downloadOptions: text("download_options", { mode: "json" }).$type<{
-    stopAfterCompleted?: number;
-    stopAfterSkipped?: number;
-    stopAfterPosts?: number;
-  }>(),
-  scheduleInterval: integer("schedule_interval"), // in seconds
-  scheduleCron: text("schedule_cron"), // cron pattern string
-  nextRunAt: integer("next_run_at", { mode: "timestamp" }),
-  lastRunAt: integer("last_run_at", { mode: "timestamp" }),
-  enabled: integer("enabled", { mode: "boolean" }).default(true),
-  createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
-    () => new Date(),
-  ),
-});
-
-export const scrapeHistory = sqliteTable("scrape_history", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  sourceId: integer("source_id")
-    .references(() => sources.id, { onDelete: "cascade" })
-    .notNull(),
-  startTime: integer("start_time", { mode: "timestamp" }).notNull(),
-  endTime: integer("end_time", { mode: "timestamp" }),
-  status: text("status")
-    .$type<"running" | "completed" | "stopped" | "failed">()
-    .notNull(),
-  filesDownloaded: integer("files_downloaded").default(0),
-  bytesDownloaded: integer("bytes_downloaded").default(0),
-  errorCount: integer("error_count").default(0),
-  skippedCount: integer("skipped_count").default(0),
-  postsProcessed: integer("posts_processed").default(0),
-  averageSpeed: integer("average_speed").default(0), // bytes per second
-  lastError: text("last_error"),
-  logPath: text("log_path"),
-  cursor: text("cursor"), // gallery-dl resume cursor for continuing failed scrapes
-  taskId: integer("task_id").references(() => scrapingTasks.id, {
-    onDelete: "set null",
+export const scraperDownloadLogs = sqliteTable(
+  "scraper_download_logs",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    sourceId: integer("source_id")
+      .references(() => sources.id, { onDelete: "cascade" })
+      .notNull(),
+    filePath: text("file_path").notNull().unique(), // Unique path to map back to source
+    createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
+      () => new Date(),
+    ),
+  },
+  (table) => ({
+    sourceIdIdx: index("idx_scraper_download_logs_source_id").on(
+      table.sourceId,
+    ),
   }),
-});
+);
+
+export const scrapingTasks = sqliteTable(
+  "scraping_tasks",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    sourceId: integer("source_id")
+      .references(() => sources.id, { onDelete: "cascade" })
+      .notNull(),
+    name: text("name"),
+    downloadOptions: text("download_options", { mode: "json" }).$type<{
+      stopAfterCompleted?: number;
+      stopAfterSkipped?: number;
+      stopAfterPosts?: number;
+    }>(),
+    scheduleInterval: integer("schedule_interval"), // in seconds
+    scheduleCron: text("schedule_cron"), // cron pattern string
+    nextRunAt: integer("next_run_at", { mode: "timestamp" }),
+    lastRunAt: integer("last_run_at", { mode: "timestamp" }),
+    enabled: integer("enabled", { mode: "boolean" }).default(true),
+    createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
+      () => new Date(),
+    ),
+  },
+  (table) => ({
+    sourceIdIdx: index("idx_scraping_tasks_source_id").on(table.sourceId),
+  }),
+);
+
+export const scrapeHistory = sqliteTable(
+  "scrape_history",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    sourceId: integer("source_id")
+      .references(() => sources.id, { onDelete: "cascade" })
+      .notNull(),
+    startTime: integer("start_time", { mode: "timestamp" }).notNull(),
+    endTime: integer("end_time", { mode: "timestamp" }),
+    status: text("status")
+      .$type<"running" | "completed" | "stopped" | "failed">()
+      .notNull(),
+    filesDownloaded: integer("files_downloaded").default(0),
+    bytesDownloaded: integer("bytes_downloaded").default(0),
+    errorCount: integer("error_count").default(0),
+    skippedCount: integer("skipped_count").default(0),
+    postsProcessed: integer("posts_processed").default(0),
+    averageSpeed: integer("average_speed").default(0), // bytes per second
+    lastError: text("last_error"),
+    logPath: text("log_path"),
+    cursor: text("cursor"), // gallery-dl resume cursor for continuing failed scrapes
+    taskId: integer("task_id").references(() => scrapingTasks.id, {
+      onDelete: "set null",
+    }),
+  },
+  (table) => ({
+    sourceIdIdx: index("idx_scrape_history_source_id").on(table.sourceId),
+    taskIdIdx: index("idx_scrape_history_task_id").on(table.taskId),
+  }),
+);
 
 export const scanHistory = sqliteTable("scan_history", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -132,108 +154,143 @@ export const pixivUsers = sqliteTable("pixiv_users", {
   isAcceptRequest: integer("is_accept_request", { mode: "boolean" }),
 });
 
-export const posts = sqliteTable("posts", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  extractorType: text("extractor_type").notNull(), // 'twitter', 'pixiv', 'gelbooruv02'
-  jsonSourceId: text("json_source_id"), // Original platform ID (tweet_id, pixiv_id)
-  internalSourceId: integer("internal_source_id").references(() => sources.id, {
-    onDelete: "cascade",
+export const posts = sqliteTable(
+  "posts",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    extractorType: text("extractor_type").notNull(), // 'twitter', 'pixiv', 'gelbooruv02'
+    jsonSourceId: text("json_source_id"), // Original platform ID (tweet_id, pixiv_id)
+    internalSourceId: integer("internal_source_id").references(
+      () => sources.id,
+      {
+        onDelete: "cascade",
+      },
+    ),
+    userId: text("user_id"), // Generic user identifier
+    date: text("date"), // Original creation date
+    title: text("title"),
+    content: text("content"), // caption, body, etc.
+    url: text("url"), // Link to original post
+    metadataPath: text("metadata_path"), // Path to the JSON metadata file
+    isSourceDeleted: integer("is_source_deleted", { mode: "boolean" }).default(
+      false,
+    ),
+    createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
+      () => new Date(),
+    ),
+    deletedAt: integer("deleted_at", { mode: "timestamp" }),
+  },
+  (table) => ({
+    internalSourceIdIdx: index("idx_posts_internal_source_id").on(
+      table.internalSourceId,
+    ),
   }),
-  userId: text("user_id"), // Generic user identifier
-  date: text("date"), // Original creation date
-  title: text("title"),
-  content: text("content"), // caption, body, etc.
-  url: text("url"), // Link to original post
-  metadataPath: text("metadata_path"), // Path to the JSON metadata file
-  isSourceDeleted: integer("is_source_deleted", { mode: "boolean" }).default(
-    false,
-  ),
-  createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
-    () => new Date(),
-  ),
-  deletedAt: integer("deleted_at", { mode: "timestamp" }),
-});
+);
 
-export const postDetailsTwitter = sqliteTable("post_details_twitter", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  postId: integer("post_id")
-    .references(() => posts.id, { onDelete: "cascade" })
-    .notNull(),
-  retweetId: text("retweet_id"),
-  quoteId: text("quote_id"),
-  replyId: text("reply_id"),
-  conversationId: text("conversation_id"),
-  lang: text("lang"),
-  source: text("source"),
-  sensitive: integer("sensitive", { mode: "boolean" }),
-  sensitiveFlags: text("sensitive_flags", { mode: "json" }),
-  favoriteCount: integer("favorite_count"),
-  quoteCount: integer("quote_count"),
-  replyCount: integer("reply_count"),
-  retweetCount: integer("retweet_count"),
-  bookmarkCount: integer("bookmark_count"),
-  viewCount: integer("view_count"),
-  category: text("category"),
-  subcategory: text("subcategory"),
-});
-
-export const postDetailsPixiv = sqliteTable("post_details_pixiv", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  postId: integer("post_id")
-    .references(() => posts.id, { onDelete: "cascade" })
-    .notNull(),
-  width: integer("width"),
-  height: integer("height"),
-  pageCount: integer("page_count"),
-  restrict: integer("restrict"),
-  xRestrict: integer("x_restrict"),
-  sanityLevel: integer("sanity_level"),
-  totalView: integer("total_view"),
-  totalBookmarks: integer("total_bookmarks"),
-  isBookmarked: integer("is_bookmarked", { mode: "boolean" }),
-  visible: integer("visible", { mode: "boolean" }),
-  isMuted: integer("is_muted", { mode: "boolean" }),
-  illustAiType: integer("illust_ai_type"),
-  illustBookStyle: integer("illust_book_style"),
-  tags: text("tags", { mode: "json" }),
-  category: text("category"),
-  subcategory: text("subcategory"),
-  type: text("type"), // illust, manga, ugoira
-});
-
-export const postDetailsGelbooruV02 = sqliteTable("post_details_gelbooruv02", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  postId: integer("post_id")
-    .references(() => posts.id, { onDelete: "cascade" })
-    .notNull(),
-  rating: text("rating"),
-  score: integer("score"),
-  md5: text("md5"),
-  width: integer("width"),
-  height: integer("height"),
-  tags: text("tags", { mode: "json" }),
-  directory: text("directory"),
-  source: text("source"),
-});
-
-export const mediaItems = sqliteTable("media_items", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  filePath: text("file_path").notNull(),
-  mediaType: text("media_type")
-    .$type<"image" | "video" | "audio" | "text">()
-    .default("image"),
-  capturedAt: integer("captured_at", { mode: "timestamp" }),
-  createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
-    () => new Date(),
-  ),
-  width: integer("width"),
-  height: integer("height"),
-
-  // Relationship
-  postId: integer("post_id").references(() => posts.id, {
-    onDelete: "set null",
+export const postDetailsTwitter = sqliteTable(
+  "post_details_twitter",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    postId: integer("post_id")
+      .references(() => posts.id, { onDelete: "cascade" })
+      .notNull(),
+    retweetId: text("retweet_id"),
+    quoteId: text("quote_id"),
+    replyId: text("reply_id"),
+    conversationId: text("conversation_id"),
+    lang: text("lang"),
+    source: text("source"),
+    sensitive: integer("sensitive", { mode: "boolean" }),
+    sensitiveFlags: text("sensitive_flags", { mode: "json" }),
+    favoriteCount: integer("favorite_count"),
+    quoteCount: integer("quote_count"),
+    replyCount: integer("reply_count"),
+    retweetCount: integer("retweet_count"),
+    bookmarkCount: integer("bookmark_count"),
+    viewCount: integer("view_count"),
+    category: text("category"),
+    subcategory: text("subcategory"),
+  },
+  (table) => ({
+    postIdIdx: index("idx_post_details_twitter_post_id").on(table.postId),
   }),
-});
+);
+
+export const postDetailsPixiv = sqliteTable(
+  "post_details_pixiv",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    postId: integer("post_id")
+      .references(() => posts.id, { onDelete: "cascade" })
+      .notNull(),
+    width: integer("width"),
+    height: integer("height"),
+    pageCount: integer("page_count"),
+    restrict: integer("restrict"),
+    xRestrict: integer("x_restrict"),
+    sanityLevel: integer("sanity_level"),
+    totalView: integer("total_view"),
+    totalBookmarks: integer("total_bookmarks"),
+    isBookmarked: integer("is_bookmarked", { mode: "boolean" }),
+    visible: integer("visible", { mode: "boolean" }),
+    isMuted: integer("is_muted", { mode: "boolean" }),
+    illustAiType: integer("illust_ai_type"),
+    illustBookStyle: integer("illust_book_style"),
+    tags: text("tags", { mode: "json" }),
+    category: text("category"),
+    subcategory: text("subcategory"),
+    type: text("type"), // illust, manga, ugoira
+  },
+  (table) => ({
+    postIdIdx: index("idx_post_details_pixiv_post_id").on(table.postId),
+  }),
+);
+
+export const postDetailsGelbooruV02 = sqliteTable(
+  "post_details_gelbooruv02",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    postId: integer("post_id")
+      .references(() => posts.id, { onDelete: "cascade" })
+      .notNull(),
+    rating: text("rating"),
+    score: integer("score"),
+    md5: text("md5"),
+    width: integer("width"),
+    height: integer("height"),
+    tags: text("tags", { mode: "json" }),
+    directory: text("directory"),
+    source: text("source"),
+  },
+  (table) => ({
+    postIdIdx: index("idx_post_details_gelbooruv02_post_id").on(table.postId),
+  }),
+);
+
+export const mediaItems = sqliteTable(
+  "media_items",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    filePath: text("file_path").notNull(),
+    mediaType: text("media_type")
+      .$type<"image" | "video" | "audio" | "text">()
+      .default("image"),
+    capturedAt: integer("captured_at", { mode: "timestamp" }),
+    createdAt: integer("created_at", { mode: "timestamp" }).$defaultFn(
+      () => new Date(),
+    ),
+    width: integer("width"),
+    height: integer("height"),
+
+    // Relationship
+    postId: integer("post_id").references(() => posts.id, {
+      onDelete: "set null",
+    }),
+  },
+  (table) => ({
+    postIdIdx: index("idx_media_items_post_id").on(table.postId),
+  }),
+);
 
 export const playlists = sqliteTable("playlists", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -248,19 +305,28 @@ export const playlists = sqliteTable("playlists", {
   ),
 });
 
-export const playlistItems = sqliteTable("playlist_items", {
-  id: integer("id").primaryKey({ autoIncrement: true }),
-  playlistId: integer("playlist_id")
-    .references(() => playlists.id, { onDelete: "cascade" })
-    .notNull(),
-  mediaItemId: integer("media_item_id")
-    .references(() => mediaItems.id, { onDelete: "cascade" })
-    .notNull(),
-  position: integer("position").notNull().default(0),
-  addedAt: integer("added_at", { mode: "timestamp" }).$defaultFn(
-    () => new Date(),
-  ),
-});
+export const playlistItems = sqliteTable(
+  "playlist_items",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    playlistId: integer("playlist_id")
+      .references(() => playlists.id, { onDelete: "cascade" })
+      .notNull(),
+    mediaItemId: integer("media_item_id")
+      .references(() => mediaItems.id, { onDelete: "cascade" })
+      .notNull(),
+    position: integer("position").notNull().default(0),
+    addedAt: integer("added_at", { mode: "timestamp" }).$defaultFn(
+      () => new Date(),
+    ),
+  },
+  (table) => ({
+    playlistIdIdx: index("idx_playlist_items_playlist_id").on(table.playlistId),
+    mediaItemIdIdx: index("idx_playlist_items_media_item_id").on(
+      table.mediaItemId,
+    ),
+  }),
+);
 
 export const tags = sqliteTable("tags", {
   id: integer("id").primaryKey({ autoIncrement: true }),
@@ -279,6 +345,7 @@ export const postTags = sqliteTable(
   },
   (t) => ({
     pk: primaryKey({ columns: [t.tagId, t.postId] }),
+    postIdIdx: index("idx_post_tags_post_id").on(t.postId),
   }),
 );
 


### PR DESCRIPTION
# Walkthrough - Database Indexing for Filtering Performance

We have implemented database indexes on foreign keys and commonly joined columns to optimize query performance in the gallery search API.

## Changes Completed

### 1. Database Schema
Modified [schema.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/schema.ts) to add 12 indexes across 10 tables:
- `idx_media_items_post_id` on `media_items(post_id)`
- `idx_post_details_twitter_post_id` on `post_details_twitter(post_id)`
- `idx_post_details_pixiv_post_id` on `post_details_pixiv(post_id)`
- `idx_post_details_gelbooruv02_post_id` on `post_details_gelbooruv02(post_id)`
- `idx_playlist_items_playlist_id` on `playlist_items(playlist_id)`
- `idx_playlist_items_media_item_id` on `playlist_items(media_item_id)`
- `idx_posts_internal_source_id` on `posts(internal_source_id)`
- `idx_post_tags_post_id` on `post_tags(post_id)`
- `idx_scraper_download_logs_source_id` on `scraper_download_logs(source_id)`
- `idx_scraping_tasks_source_id` on `scraping_tasks(source_id)`
- `idx_scrape_history_source_id` on `scrape_history(source_id)`
- `idx_scrape_history_task_id` on `scrape_history(task_id)`

### 2. Migration Generation
Generated migration files using `npm run db:generate`:
- SQL file: [0011_minor_magik.sql](file:///home/darkkal/Source/Remote/Github/web-gallery/drizzle/0011_minor_magik.sql)
- Journal and Snapshot meta updates.

---

## Verification Results

### 1. Migration Application
Container logs verify that the migration was successfully applied on startup:
```text
webgallery-test-1  | [DB] Applied migration (timestamp: 1781760250983)
webgallery-test-1  | [DB] Database initialized successfully.
```

### 2. Local TypeScript Compilation
Successfully built the application on the host using `npm run build` with no compile errors.

### 3. Performance Improvement
Re-ran the performance query:
```bash
curl -s -w '\nHTTP Code: %{http_code}\nTime: %{time_total}s\n' 'http://localhost:3001/api/gallery?search=tag:R-18&limit=50' -o /dev/null
```

**Results Comparison:**
- **Before Optimization:** **~24.84s**
- **After Optimization:** **~0.124s** (124ms)

This represents an approximate **200x speedup** for large result-set queries!
