### PR TITLE
e-hentai support

### DIFF
--- a/drizzle/0012_useful_vivisector.sql
+++ b/drizzle/0012_useful_vivisector.sql
@@ -1,0 +1,125 @@
+CREATE TABLE `post_details_ehentai` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`post_id` integer NOT NULL,
+	`gid` integer,
+	`token` text,
+	`eh_category` text,
+	`uploader` text,
+	`language` text,
+	`file_count` integer,
+	`rating` text,
+	`torrent_count` integer,
+	FOREIGN KEY (`post_id`) REFERENCES `posts`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_post_details_ehentai_post_id` ON `post_details_ehentai` (`post_id`);
+--> statement-breakpoint
+-- Drop old triggers
+DROP TRIGGER IF EXISTS posts_ai;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS posts_au;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS post_tags_ai;
+--> statement-breakpoint
+DROP TRIGGER IF EXISTS post_tags_ad;
+--> statement-breakpoint
+-- Create updated triggers
+CREATE TRIGGER posts_ai AFTER INSERT ON posts BEGIN
+  INSERT INTO posts_fts(rowid, title, content, user_name, user_handle, source_name, tag_names) 
+  VALUES (
+    new.id, 
+    new.title, 
+    new.content,
+    COALESCE(
+      (SELECT name FROM twitter_users WHERE id = new.user_id AND new.extractor_type = 'twitter'),
+      (SELECT name FROM pixiv_users WHERE id = new.user_id AND new.extractor_type = 'pixiv'),
+      CASE WHEN new.extractor_type IN ('ehentai', 'exhentai') THEN new.user_id ELSE '' END
+    ),
+    COALESCE(
+      (SELECT nick FROM twitter_users WHERE id = new.user_id AND new.extractor_type = 'twitter'),
+      (SELECT account FROM pixiv_users WHERE id = new.user_id AND new.extractor_type = 'pixiv'),
+      CASE WHEN new.extractor_type IN ('ehentai', 'exhentai') THEN new.user_id ELSE '' END
+    ),
+    COALESCE((SELECT name FROM sources WHERE id = new.internal_source_id), ''),
+    ''
+  );
+END;
+--> statement-breakpoint
+CREATE TRIGGER posts_au AFTER UPDATE ON posts BEGIN
+  INSERT INTO posts_fts(posts_fts, rowid, title, content, user_name, user_handle, source_name, tag_names) 
+  VALUES ('delete', old.id, old.title, old.content, '', '', '', '');
+  INSERT INTO posts_fts(rowid, title, content, user_name, user_handle, source_name, tag_names) 
+  VALUES (
+    new.id, 
+    new.title, 
+    new.content,
+    COALESCE(
+      (SELECT name FROM twitter_users WHERE id = new.user_id AND new.extractor_type = 'twitter'),
+      (SELECT name FROM pixiv_users WHERE id = new.user_id AND new.extractor_type = 'pixiv'),
+      CASE WHEN new.extractor_type IN ('ehentai', 'exhentai') THEN new.user_id ELSE '' END
+    ),
+    COALESCE(
+      (SELECT nick FROM twitter_users WHERE id = new.user_id AND new.extractor_type = 'twitter'),
+      (SELECT account FROM pixiv_users WHERE id = new.user_id AND new.extractor_type = 'pixiv'),
+      CASE WHEN new.extractor_type IN ('ehentai', 'exhentai') THEN new.user_id ELSE '' END
+    ),
+    COALESCE((SELECT name FROM sources WHERE id = new.internal_source_id), ''),
+    COALESCE((SELECT group_concat(t.name, ' ') FROM post_tags pt JOIN tags t ON pt.tag_id = t.id WHERE pt.post_id = new.id), '')
+  );
+END;
+--> statement-breakpoint
+CREATE TRIGGER post_tags_ai AFTER INSERT ON post_tags BEGIN
+  INSERT INTO posts_fts(posts_fts, rowid, title, content, user_name, user_handle, source_name, tag_names)
+  VALUES ('delete', new.post_id, (SELECT title FROM posts WHERE id = new.post_id), (SELECT content FROM posts WHERE id = new.post_id), '', '', '', '');
+  
+  INSERT INTO posts_fts(rowid, title, content, user_name, user_handle, source_name, tag_names)
+  SELECT 
+    p.id, 
+    p.title, 
+    p.content,
+    COALESCE(
+      tu.name, 
+      pu.name, 
+      CASE WHEN p.extractor_type IN ('ehentai', 'exhentai') THEN p.user_id ELSE '' END
+    ), 
+    COALESCE(
+      tu.nick, 
+      pu.account, 
+      CASE WHEN p.extractor_type IN ('ehentai', 'exhentai') THEN p.user_id ELSE '' END
+    ), 
+    COALESCE(s.name, ''),
+    COALESCE((SELECT group_concat(t.name, ' ') FROM post_tags pt JOIN tags t ON pt.tag_id = t.id WHERE pt.post_id = p.id), '')
+  FROM posts p
+    LEFT JOIN twitter_users tu ON p.extractor_type = 'twitter' AND p.user_id = tu.id
+    LEFT JOIN pixiv_users pu ON p.extractor_type = 'pixiv' AND p.user_id = pu.id
+    LEFT JOIN sources s ON p.internal_source_id = s.id
+  WHERE p.id = new.post_id;
+END;
+--> statement-breakpoint
+CREATE TRIGGER post_tags_ad AFTER DELETE ON post_tags BEGIN
+  INSERT INTO posts_fts(posts_fts, rowid, title, content, user_name, user_handle, source_name, tag_names)
+  VALUES ('delete', old.post_id, (SELECT title FROM posts WHERE id = old.post_id), (SELECT content FROM posts WHERE id = old.post_id), '', '', '', '');
+  
+  INSERT INTO posts_fts(rowid, title, content, user_name, user_handle, source_name, tag_names)
+  SELECT 
+    p.id, 
+    p.title, 
+    p.content,
+    COALESCE(
+      tu.name, 
+      pu.name, 
+      CASE WHEN p.extractor_type IN ('ehentai', 'exhentai') THEN p.user_id ELSE '' END
+    ), 
+    COALESCE(
+      tu.nick, 
+      pu.account, 
+      CASE WHEN p.extractor_type IN ('ehentai', 'exhentai') THEN p.user_id ELSE '' END
+    ), 
+    COALESCE(s.name, ''),
+    COALESCE((SELECT group_concat(t.name, ' ') FROM post_tags pt JOIN tags t ON pt.tag_id = t.id WHERE pt.post_id = p.id), '')
+  FROM posts p
+    LEFT JOIN twitter_users tu ON p.extractor_type = 'twitter' AND p.user_id = tu.id
+    LEFT JOIN pixiv_users pu ON p.extractor_type = 'pixiv' AND p.user_id = pu.id
+    LEFT JOIN sources s ON p.internal_source_id = s.id
+  WHERE p.id = old.post_id;
+END;

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,1752 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f62827ea-f486-4923-a830-fb092a81eb1f",
+  "prevId": "58fffd85-cb96-4224-8fb5-f504adb1e1d9",
+  "tables": {
+    "gallerydl_extractor_types": {
+      "name": "gallerydl_extractor_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "library_statistics": {
+      "name": "library_statistics",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_media_items": {
+          "name": "total_media_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tags": {
+          "name": "total_tags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_extractors": {
+          "name": "total_extractors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "media_items": {
+      "name": "media_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_type": {
+          "name": "media_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'image'"
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_media_items_post_id": {
+          "name": "idx_media_items_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "media_items_post_id_posts_id_fk": {
+          "name": "media_items_post_id_posts_id_fk",
+          "tableFrom": "media_items",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pixiv_users": {
+      "name": "pixiv_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "account": {
+          "name": "account",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_followed": {
+          "name": "is_followed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_accept_request": {
+          "name": "is_accept_request",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlist_items": {
+      "name": "playlist_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "media_item_id": {
+          "name": "media_item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_playlist_items_playlist_id": {
+          "name": "idx_playlist_items_playlist_id",
+          "columns": ["playlist_id"],
+          "isUnique": false
+        },
+        "idx_playlist_items_media_item_id": {
+          "name": "idx_playlist_items_media_item_id",
+          "columns": ["media_item_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "playlist_items_playlist_id_playlists_id_fk": {
+          "name": "playlist_items_playlist_id_playlists_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "playlists",
+          "columnsFrom": ["playlist_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_items_media_item_id_media_items_id_fk": {
+          "name": "playlist_items_media_item_id_media_items_id_fk",
+          "tableFrom": "playlist_items",
+          "tableTo": "media_items",
+          "columnsFrom": ["media_item_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "playlists": {
+      "name": "playlists",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "thumbnail": {
+          "name": "thumbnail",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_ehentai": {
+      "name": "post_details_ehentai",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "gid": {
+          "name": "gid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "eh_category": {
+          "name": "eh_category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploader": {
+          "name": "uploader",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_count": {
+          "name": "file_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "torrent_count": {
+          "name": "torrent_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_details_ehentai_post_id": {
+          "name": "idx_post_details_ehentai_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_details_ehentai_post_id_posts_id_fk": {
+          "name": "post_details_ehentai_post_id_posts_id_fk",
+          "tableFrom": "post_details_ehentai",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_gelbooruv02": {
+      "name": "post_details_gelbooruv02",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "md5": {
+          "name": "md5",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "directory": {
+          "name": "directory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_details_gelbooruv02_post_id": {
+          "name": "idx_post_details_gelbooruv02_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_details_gelbooruv02_post_id_posts_id_fk": {
+          "name": "post_details_gelbooruv02_post_id_posts_id_fk",
+          "tableFrom": "post_details_gelbooruv02",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_pixiv": {
+      "name": "post_details_pixiv",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "page_count": {
+          "name": "page_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "restrict": {
+          "name": "restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "x_restrict": {
+          "name": "x_restrict",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sanity_level": {
+          "name": "sanity_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_view": {
+          "name": "total_view",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "total_bookmarks": {
+          "name": "total_bookmarks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_bookmarked": {
+          "name": "is_bookmarked",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "visible": {
+          "name": "visible",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_muted": {
+          "name": "is_muted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_ai_type": {
+          "name": "illust_ai_type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "illust_book_style": {
+          "name": "illust_book_style",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_details_pixiv_post_id": {
+          "name": "idx_post_details_pixiv_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_details_pixiv_post_id_posts_id_fk": {
+          "name": "post_details_pixiv_post_id_posts_id_fk",
+          "tableFrom": "post_details_pixiv",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_details_twitter": {
+      "name": "post_details_twitter",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "retweet_id": {
+          "name": "retweet_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_id": {
+          "name": "quote_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_id": {
+          "name": "reply_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "lang": {
+          "name": "lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive": {
+          "name": "sensitive",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sensitive_flags": {
+          "name": "sensitive_flags",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favorite_count": {
+          "name": "favorite_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "quote_count": {
+          "name": "quote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "reply_count": {
+          "name": "reply_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retweet_count": {
+          "name": "retweet_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "bookmark_count": {
+          "name": "bookmark_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "view_count": {
+          "name": "view_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "subcategory": {
+          "name": "subcategory",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_details_twitter_post_id": {
+          "name": "idx_post_details_twitter_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_details_twitter_post_id_posts_id_fk": {
+          "name": "post_details_twitter_post_id_posts_id_fk",
+          "tableFrom": "post_details_twitter",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "post_tags": {
+      "name": "post_tags",
+      "columns": {
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_post_tags_post_id": {
+          "name": "idx_post_tags_post_id",
+          "columns": ["post_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "post_tags_tag_id_tags_id_fk": {
+          "name": "post_tags_tag_id_tags_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "tags",
+          "columnsFrom": ["tag_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_tags_post_id_posts_id_fk": {
+          "name": "post_tags_post_id_posts_id_fk",
+          "tableFrom": "post_tags",
+          "tableTo": "posts",
+          "columnsFrom": ["post_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "post_tags_tag_id_post_id_pk": {
+          "columns": ["tag_id", "post_id"],
+          "name": "post_tags_tag_id_post_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "posts": {
+      "name": "posts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "json_source_id": {
+          "name": "json_source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "internal_source_id": {
+          "name": "internal_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "metadata_path": {
+          "name": "metadata_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_source_deleted": {
+          "name": "is_source_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_posts_internal_source_id": {
+          "name": "idx_posts_internal_source_id",
+          "columns": ["internal_source_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "posts_internal_source_id_sources_id_fk": {
+          "name": "posts_internal_source_id_sources_id_fk",
+          "tableFrom": "posts",
+          "tableTo": "sources",
+          "columnsFrom": ["internal_source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scan_history": {
+      "name": "scan_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scan_type": {
+          "name": "scan_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'full'"
+        },
+        "files_processed": {
+          "name": "files_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_added": {
+          "name": "files_added",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_updated": {
+          "name": "files_updated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "files_deleted": {
+          "name": "files_deleted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scrape_history": {
+      "name": "scrape_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "end_time": {
+          "name": "end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "files_downloaded": {
+          "name": "files_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "bytes_downloaded": {
+          "name": "bytes_downloaded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "skipped_count": {
+          "name": "skipped_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "posts_processed": {
+          "name": "posts_processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "average_speed": {
+          "name": "average_speed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "log_path": {
+          "name": "log_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_scrape_history_source_id": {
+          "name": "idx_scrape_history_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        },
+        "idx_scrape_history_task_id": {
+          "name": "idx_scrape_history_task_id",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scrape_history_source_id_sources_id_fk": {
+          "name": "scrape_history_source_id_sources_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scrape_history_task_id_scraping_tasks_id_fk": {
+          "name": "scrape_history_task_id_scraping_tasks_id_fk",
+          "tableFrom": "scrape_history",
+          "tableTo": "scraping_tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraper_download_logs": {
+      "name": "scraper_download_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "scraper_download_logs_file_path_unique": {
+          "name": "scraper_download_logs_file_path_unique",
+          "columns": ["file_path"],
+          "isUnique": true
+        },
+        "idx_scraper_download_logs_source_id": {
+          "name": "idx_scraper_download_logs_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scraper_download_logs_source_id_sources_id_fk": {
+          "name": "scraper_download_logs_source_id_sources_id_fk",
+          "tableFrom": "scraper_download_logs",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scraping_tasks": {
+      "name": "scraping_tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_options": {
+          "name": "download_options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_interval": {
+          "name": "schedule_interval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "schedule_cron": {
+          "name": "schedule_cron",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_scraping_tasks_source_id": {
+          "name": "idx_scraping_tasks_source_id",
+          "columns": ["source_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scraping_tasks_source_id_sources_id_fk": {
+          "name": "scraping_tasks_source_id_sources_id_fk",
+          "tableFrom": "scraping_tasks",
+          "tableTo": "sources",
+          "columnsFrom": ["source_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "sources": {
+      "name": "sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "extractor_type": {
+          "name": "extractor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "sources_extractor_type_gallerydl_extractor_types_id_fk": {
+          "name": "sources_extractor_type_gallerydl_extractor_types_id_fk",
+          "tableFrom": "sources",
+          "tableTo": "gallerydl_extractor_types",
+          "columnsFrom": ["extractor_type"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "statistics_history": {
+      "name": "statistics_history",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date_type": {
+          "name": "date_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'import'"
+        },
+        "total_posts": {
+          "name": "total_posts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_media_items": {
+          "name": "total_media_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_tags": {
+          "name": "total_tags",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_users": {
+          "name": "total_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "total_extractors": {
+          "name": "total_extractors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "storage_bytes": {
+          "name": "storage_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_statistics_history_date": {
+          "name": "idx_statistics_history_date",
+          "columns": ["date", "date_type"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_unique": {
+          "name": "tags_name_unique",
+          "columns": ["name"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "twitter_users": {
+      "name": "twitter_users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nick": {
+          "name": "nick",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verified": {
+          "name": "verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "protected": {
+          "name": "protected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_banner": {
+          "name": "profile_banner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "profile_image": {
+          "name": "profile_image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "favourites_count": {
+          "name": "favourites_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "followers_count": {
+          "name": "followers_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "friends_count": {
+          "name": "friends_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "listed_count": {
+          "name": "listed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "media_count": {
+          "name": "media_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "statuses_count": {
+          "name": "statuses_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1781760250983,
       "tag": "0011_minor_magik",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1781778304527,
+      "tag": "0012_useful_vivisector",
+      "breakpoints": true
     }
   ]
 }

--- a/gallery-dl-default.conf
+++ b/gallery-dl-default.conf
@@ -65,7 +65,7 @@
         {
             "name": "metadata",
             "event": "post",
-            "filename": "{post_id|tweet_id|id}.json"
+            "filename": "{post_id|tweet_id|id|gid|filename}.json"
         },
         "post-counter":
         {

--- a/gallery-dl-default.conf
+++ b/gallery-dl-default.conf
@@ -40,6 +40,14 @@
             "tags": "original",
             "metadata-bookmark": true,
             "captions": true
+        },
+        "ehentai": {
+            "directory": ["{category}", "{gid}"],
+            "filename": "{filename}"
+        },
+        "exhentai": {
+            "directory": ["{category}", "{gid}"],
+            "filename": "{filename}"
         }
     },
 

--- a/gallery-dl-default.conf
+++ b/gallery-dl-default.conf
@@ -43,11 +43,13 @@
         },
         "ehentai": {
             "directory": ["{category}", "{gid}"],
-            "filename": "{filename}"
+            "filename": "{filename}",
+            "tags": false
         },
         "exhentai": {
             "directory": ["{category}", "{gid}"],
-            "filename": "{filename}"
+            "filename": "{filename}",
+            "tags": false
         }
     },
 

--- a/src/app/actions/gallery.ts
+++ b/src/app/actions/gallery.ts
@@ -82,6 +82,10 @@ export async function refetchPostData(postIds: number[]) {
               isHostnameInDomain(hostname, "safebooru.org")
             ) {
               type = "gelbooruv02";
+            } else if (isHostnameInDomain(hostname, "e-hentai.org")) {
+              type = "ehentai";
+            } else if (isHostnameInDomain(hostname, "exhentai.org")) {
+              type = "exhentai";
             }
           } catch {}
 

--- a/src/app/api/autocomplete/route.ts
+++ b/src/app/api/autocomplete/route.ts
@@ -45,7 +45,13 @@ export async function GET(request: NextRequest) {
       case "source":
       case "extractor": {
         // For source and extractor, return static values matching posts.extractorType
-        const staticValues = ["twitter", "pixiv", "gelbooruv02"];
+        const staticValues = [
+          "twitter",
+          "pixiv",
+          "gelbooruv02",
+          "ehentai",
+          "exhentai",
+        ];
         suggestions = staticValues
           .filter((v) => v.startsWith(q.toLowerCase()))
           .map((v) => ({

--- a/src/app/timeline/page.module.css
+++ b/src/app/timeline/page.module.css
@@ -163,6 +163,16 @@
   color: #0096fa;
 }
 
+.badge.ehentai {
+  background: hsla(142, 70%, 45%, 0.15);
+  color: hsl(142, 70%, 45%);
+}
+
+.badge.exhentai {
+  background: hsla(0, 75%, 50%, 0.15);
+  color: hsl(0, 75%, 55%);
+}
+
 .sourceLink {
   color: hsl(var(--muted-foreground));
   text-decoration: none;

--- a/src/lib/db/repositories/posts.ts
+++ b/src/lib/db/repositories/posts.ts
@@ -28,7 +28,7 @@ import { parseSearchQuery } from "@/lib/utils/search-parser";
 
 export type TimelinePost = {
   id: string;
-  type: "twitter" | "pixiv" | "other";
+  type: "twitter" | "pixiv" | "ehentai" | "exhentai" | "other";
   internalDbId?: number;
   date: Date;
   author?: {
@@ -261,9 +261,11 @@ export async function getTimelinePosts(filters?: {
 
   const timelinePosts: TimelinePost[] = rawPosts.map((row) => {
     let stats: TimelinePost["stats"];
-    let type: "twitter" | "pixiv" | "other" = "other";
+    let type: "twitter" | "pixiv" | "ehentai" | "exhentai" | "other" = "other";
     if (row.post.extractorType === "twitter") type = "twitter";
     else if (row.post.extractorType === "pixiv") type = "pixiv";
+    else if (row.post.extractorType === "ehentai") type = "ehentai";
+    else if (row.post.extractorType === "exhentai") type = "exhentai";
 
     let author: TimelinePost["author"];
     let pixivMetadata: TimelinePost["pixivMetadata"];
@@ -281,6 +283,11 @@ export async function getTimelinePosts(filters?: {
         handle: row.user?.nick || undefined,
         avatar: row.user?.id ? `/api/avatar/twitter/${row.user.id}` : undefined,
         url: row.user ? `https://twitter.com/${row.user.nick}` : undefined,
+      };
+    } else if (type === "ehentai" || type === "exhentai") {
+      author = {
+        name: row.post.userId || "Anonymous",
+        handle: undefined,
       };
     } else if (type === "pixiv") {
       stats = {

--- a/src/lib/db/repositories/sources.ts
+++ b/src/lib/db/repositories/sources.ts
@@ -9,7 +9,7 @@ import {
 } from "@/lib/db/schema";
 
 export async function addSource(url: string, name?: string) {
-  let type: "twitter" | "pixiv" | "gallery-dl" | "gelbooruv02" = "gallery-dl";
+  let type: string = "gallery-dl";
 
   try {
     const parsed = new URL(url);
@@ -31,6 +31,16 @@ export async function addSource(url: string, name?: string) {
       hostname.endsWith(".safebooru.org")
     ) {
       type = "gelbooruv02";
+    } else if (
+      hostname === "e-hentai.org" ||
+      hostname.endsWith(".e-hentai.org")
+    ) {
+      type = "ehentai";
+    } else if (
+      hostname === "exhentai.org" ||
+      hostname.endsWith(".exhentai.org")
+    ) {
+      type = "exhentai";
     }
   } catch {
     // Treat as generic gallery-dl

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -267,6 +267,27 @@ export const postDetailsGelbooruV02 = sqliteTable(
   }),
 );
 
+export const postDetailsEHentai = sqliteTable(
+  "post_details_ehentai",
+  {
+    id: integer("id").primaryKey({ autoIncrement: true }),
+    postId: integer("post_id")
+      .references(() => posts.id, { onDelete: "cascade" })
+      .notNull(),
+    gid: integer("gid"),
+    token: text("token"),
+    ehCategory: text("eh_category"),
+    uploader: text("uploader"),
+    language: text("language"),
+    filecount: integer("file_count"),
+    rating: text("rating"),
+    torrentcount: integer("torrent_count"),
+  },
+  (table) => ({
+    postIdIdx: index("idx_post_details_ehentai_post_id").on(table.postId),
+  }),
+);
+
 export const mediaItems = sqliteTable(
   "media_items",
   {
@@ -420,6 +441,10 @@ export const postsRelations = relations(posts, ({ one, many }) => ({
     fields: [posts.id],
     references: [postDetailsGelbooruV02.postId],
   }),
+  ehentaiDetails: one(postDetailsEHentai, {
+    fields: [posts.id],
+    references: [postDetailsEHentai.postId],
+  }),
   mediaItems: many(mediaItems),
   tags: many(postTags),
 }));
@@ -449,6 +474,16 @@ export const postDetailsGelbooruV02Relations = relations(
   ({ one }) => ({
     post: one(posts, {
       fields: [postDetailsGelbooruV02.postId],
+      references: [posts.id],
+    }),
+  }),
+);
+
+export const postDetailsEHentaiRelations = relations(
+  postDetailsEHentai,
+  ({ one }) => ({
+    post: one(posts, {
+      fields: [postDetailsEHentai.postId],
       references: [posts.id],
     }),
   }),

--- a/src/lib/library/processors/ehentai.ts
+++ b/src/lib/library/processors/ehentai.ts
@@ -1,0 +1,180 @@
+import path from "node:path";
+import { eq } from "drizzle-orm";
+import { paths } from "@/lib/config";
+import { postDetailsEHentai, posts, postTags, tags } from "@/lib/db/schema";
+import type { IMetadataProcessor } from "@/lib/library/processors/base";
+import type { ProcessorContext, ProcessTask } from "@/lib/library/types";
+
+export interface EHentaiMeta {
+  gid?: number;
+  token?: string;
+  title?: string;
+  title_jpn?: string;
+  eh_category?: string;
+  uploader?: string;
+  date?: string;
+  parent?: string;
+  expunged?: boolean;
+  language?: string;
+  filesize?: number;
+  filecount?: string | number;
+  favorites?: string | number;
+  rating?: string | number;
+  torrentcount?: string | number;
+  lang?: string;
+  tags?: string[];
+  category?: string;
+  subcategory?: string;
+}
+
+export class EHentaiProcessor implements IMetadataProcessor<EHentaiMeta> {
+  private extractorType: string;
+
+  constructor(extractorType: string) {
+    this.extractorType = extractorType;
+  }
+
+  async process(
+    meta: EHentaiMeta,
+    task: ProcessTask,
+    context: ProcessorContext,
+  ): Promise<number | null> {
+    const { tx, existingPosts, existingTags, internalSourceId } = context;
+
+    let postId: number | null = null;
+
+    const gid = meta.gid ? String(meta.gid) : null;
+    if (!gid) {
+      console.warn("[EHentaiProcessor] Missing gid in metadata");
+      return null;
+    }
+
+    const key = `${this.extractorType}:${gid}`;
+
+    if (!existingPosts.has(key)) {
+      // Create a new post record
+      const inserted = await tx
+        .insert(posts)
+        .values({
+          extractorType: this.extractorType,
+          jsonSourceId: gid,
+          internalSourceId: internalSourceId,
+          userId: meta.uploader || null,
+          date: meta.date || null,
+          title: meta.title_jpn || meta.title || null,
+          content: meta.title || meta.title_jpn || null,
+          url:
+            this.extractorType === "exhentai"
+              ? `https://exhentai.org/g/${gid}/${meta.token || ""}`
+              : `https://e-hentai.org/g/${gid}/${meta.token || ""}`,
+          metadataPath: task.jsonPath
+            ? path
+                .relative(path.dirname(paths.downloads), task.jsonPath)
+                .split(path.sep)
+                .join("/")
+            : null,
+          createdAt: new Date(),
+        })
+        .returning({ id: posts.id });
+
+      postId = inserted[0]?.id ?? null;
+      if (postId === null) {
+        console.warn(
+          `[EHentaiProcessor] Failed to insert post for gid: ${gid}`,
+        );
+        return null;
+      }
+      existingPosts.set(key, postId);
+
+      // Insert detail table record
+      await tx.insert(postDetailsEHentai).values({
+        postId: postId,
+        gid: meta.gid ? Number(meta.gid) : null,
+        token: meta.token || null,
+        ehCategory: meta.eh_category || null,
+        uploader: meta.uploader || null,
+        language: meta.language || null,
+        filecount: meta.filecount ? Number(meta.filecount) : null,
+        rating: meta.rating ? String(meta.rating) : null,
+        torrentcount: meta.torrentcount ? Number(meta.torrentcount) : null,
+      });
+    } else {
+      postId = existingPosts.get(key) || null;
+      if (postId) {
+        // Update existing post
+        const updateSet: Record<string, unknown> = {
+          date: meta.date || null,
+          title: meta.title_jpn || meta.title || null,
+          content: meta.title || meta.title_jpn || null,
+          url:
+            this.extractorType === "exhentai"
+              ? `https://exhentai.org/g/${gid}/${meta.token || ""}`
+              : `https://e-hentai.org/g/${gid}/${meta.token || ""}`,
+        };
+        if (internalSourceId) {
+          updateSet.internalSourceId = internalSourceId;
+        }
+        if (task.jsonPath) {
+          updateSet.metadataPath = path
+            .relative(path.dirname(paths.downloads), task.jsonPath)
+            .split(path.sep)
+            .join("/");
+        }
+        await tx.update(posts).set(updateSet).where(eq(posts.id, postId));
+
+        // Update detail table record
+        await tx
+          .update(postDetailsEHentai)
+          .set({
+            gid: meta.gid ? Number(meta.gid) : null,
+            token: meta.token || null,
+            ehCategory: meta.eh_category || null,
+            uploader: meta.uploader || null,
+            language: meta.language || null,
+            filecount: meta.filecount ? Number(meta.filecount) : null,
+            rating: meta.rating ? String(meta.rating) : null,
+            torrentcount: meta.torrentcount ? Number(meta.torrentcount) : null,
+          })
+          .where(eq(postDetailsEHentai.postId, postId));
+      }
+    }
+
+    // Process Tags
+    if (postId && meta.tags && Array.isArray(meta.tags)) {
+      for (const rawTag of meta.tags) {
+        if (!rawTag) continue;
+        const tagName = rawTag.trim();
+        let tagId = existingTags.get(tagName);
+
+        if (!tagId) {
+          const newTag = await tx
+            .insert(tags)
+            .values({ name: tagName })
+            .onConflictDoNothing()
+            .returning({ id: tags.id });
+          if (newTag.length > 0) tagId = newTag[0].id;
+          else {
+            const e = await tx
+              .select({ id: tags.id })
+              .from(tags)
+              .where(eq(tags.name, tagName));
+            if (e.length > 0) tagId = e[0].id;
+          }
+          if (tagId) existingTags.set(tagName, tagId);
+        }
+
+        if (tagId && postId) {
+          await tx
+            .insert(postTags)
+            .values({
+              tagId,
+              postId,
+            })
+            .onConflictDoNothing();
+        }
+      }
+    }
+
+    return postId;
+  }
+}

--- a/src/lib/library/processors/factory.ts
+++ b/src/lib/library/processors/factory.ts
@@ -1,4 +1,5 @@
 import type { IMetadataProcessor } from "@/lib/library/processors/base";
+import { EHentaiProcessor } from "@/lib/library/processors/ehentai";
 import { GelbooruProcessor } from "@/lib/library/processors/gelbooru";
 import { PixivProcessor } from "@/lib/library/processors/pixiv";
 import { TwitterProcessor } from "@/lib/library/processors/twitter";
@@ -12,6 +13,9 @@ export const MetadataProcessorFactory = {
         return new PixivProcessor();
       case "gelbooruv02":
         return new GelbooruProcessor();
+      case "ehentai":
+      case "exhentai":
+        return new EHentaiProcessor(extractorType);
       default:
         return null;
     }

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -250,7 +250,14 @@ export async function syncLibrary(options?: SyncOptions) {
           ".png",
           ".gif",
           ".webp",
-        ].includes(ext)
+        ].includes(ext) ||
+        (ext === "" &&
+          (dir.toLowerCase().includes(`${path.sep}ehentai${path.sep}`) ||
+            dir.toLowerCase().includes(`${path.sep}exhentai${path.sep}`) ||
+            dir.toLowerCase().endsWith(`${path.sep}ehentai`) ||
+            dir.toLowerCase().endsWith(`${path.sep}exhentai`) ||
+            dir.toLowerCase().includes("/ehentai/") ||
+            dir.toLowerCase().includes("/exhentai/")))
       )
         group.mediaFiles.push(absPath);
     });

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -337,7 +337,7 @@ export async function syncLibrary(options?: SyncOptions) {
     const processedPaths = new Set<string>();
     const tasks: ProcessTask[] = [];
 
-    for (const [, group] of dirGroups) {
+    for (const [dirPath, group] of dirGroups) {
       const mediaToJson = new Map<string, string>();
       const usedJsons = new Set<string>();
 
@@ -373,6 +373,24 @@ export async function syncLibrary(options?: SyncOptions) {
             }
           }
         }
+
+        // 3. Fallback for gallery-based platforms (e-hentai, exhentai) where images are named by page
+        // (e.g. 001.jpg, 002.jpg) and don't match the metadata filename (e.g. {gid}.json / None.json)
+        // but reside in the same directory.
+        if (!bestMatchJson && group.jsonFiles.length === 1) {
+          const dirLower = dirPath.toLowerCase();
+          if (
+            dirLower.includes(`${path.sep}ehentai${path.sep}`) ||
+            dirLower.includes(`${path.sep}exhentai${path.sep}`) ||
+            dirLower.endsWith(`${path.sep}ehentai`) ||
+            dirLower.endsWith(`${path.sep}exhentai`) ||
+            dirLower.includes("/ehentai/") ||
+            dirLower.includes("/exhentai/")
+          ) {
+            bestMatchJson = group.jsonFiles[0];
+          }
+        }
+
         if (bestMatchJson) {
           mediaToJson.set(mediaPath, bestMatchJson);
           usedJsons.add(bestMatchJson);

--- a/src/lib/library/scanner.ts
+++ b/src/lib/library/scanner.ts
@@ -323,6 +323,8 @@ export async function syncLibrary(options?: SyncOptions) {
         { id: "pixiv", description: "Pixiv" },
         { id: "gelbooruv02", description: "Gelbooru/Safebooru" },
         { id: "gallery-dl", description: "Generic gallery-dl" },
+        { id: "ehentai", description: "E-Hentai" },
+        { id: "exhentai", description: "ExHentai" },
       ])
       .onConflictDoNothing();
 

--- a/src/lib/scrapers/runner.ts
+++ b/src/lib/scrapers/runner.ts
@@ -13,6 +13,30 @@ export interface ScrapeLimits {
   stopAfterPosts?: number;
 }
 
+// biome-ignore lint/suspicious/noExplicitAny: Deep merge requires handling untyped JSON structures
+function deepMerge(target: any, source: any): any {
+  if (
+    target &&
+    typeof target === "object" &&
+    source &&
+    typeof source === "object"
+  ) {
+    if (Array.isArray(source)) {
+      return source;
+    }
+    const result = { ...target };
+    for (const key of Object.keys(source)) {
+      if (key in target) {
+        result[key] = deepMerge(target[key], source[key]);
+      } else {
+        result[key] = source[key];
+      }
+    }
+    return result;
+  }
+  return source !== undefined ? source : target;
+}
+
 export class ScraperRunner {
   private basePath: string;
 
@@ -67,15 +91,27 @@ export class ScraperRunner {
       }
     }
 
-    if (!fs.existsSync(configPath)) {
-      if (fs.existsSync(resolvedDefaultConfigPath)) {
-        fs.copyFileSync(resolvedDefaultConfigPath, configPath);
-      } else {
-        console.warn(
-          "Warning: gallery-dl-default.conf not found. Skipping default config creation.",
+    let defaultConfigJson: Record<string, unknown> = {};
+    if (fs.existsSync(resolvedDefaultConfigPath)) {
+      try {
+        defaultConfigJson = JSON.parse(
+          fs.readFileSync(resolvedDefaultConfigPath, "utf-8"),
         );
-      }
+      } catch {}
     }
+
+    let existingConfigJson: Record<string, unknown> = {};
+    if (fs.existsSync(configPath)) {
+      try {
+        existingConfigJson = JSON.parse(fs.readFileSync(configPath, "utf-8"));
+      } catch {}
+    }
+
+    // Merge existing config on top of the default template config
+    const configJson = deepMerge(defaultConfigJson, existingConfigJson);
+
+    // Write updated config
+    fs.writeFileSync(configPath, JSON.stringify(configJson, null, 4), "utf-8");
   }
 
   run(

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -112,6 +112,34 @@ export async function getAppSettings(): Promise<AppSettings> {
  * Saves both app and scraper settings to settings.json,
  * and updates gallery-dl.conf dynamically.
  */
+// biome-ignore lint/suspicious/noExplicitAny: Deep merge requires handling untyped JSON structures
+function deepMerge(target: any, source: any): any {
+  if (
+    target &&
+    typeof target === "object" &&
+    source &&
+    typeof source === "object"
+  ) {
+    if (Array.isArray(source)) {
+      return source;
+    }
+    const result = { ...target };
+    for (const key of Object.keys(source)) {
+      if (key in target) {
+        result[key] = deepMerge(target[key], source[key]);
+      } else {
+        result[key] = source[key];
+      }
+    }
+    return result;
+  }
+  return source !== undefined ? source : target;
+}
+
+/**
+ * Saves both app and scraper settings to settings.json,
+ * and updates gallery-dl.conf dynamically.
+ */
 export async function saveSettings(settings: SystemSettings): Promise<void> {
   // Ensure DATA_DIR and scraper directories exist
   const dirs = [paths.dataDir, paths.galleryDl.root];
@@ -156,35 +184,33 @@ export async function saveSettings(settings: SystemSettings): Promise<void> {
     }
   }
 
-  let configJson: Record<string, unknown> = {};
-
-  if (existsSync(configPath)) {
+  let defaultConfigJson: Record<string, unknown> = {};
+  if (existsSync(resolvedDefaultConfigPath)) {
     try {
-      configJson = JSON.parse(await fs.readFile(configPath, "utf-8")) as Record<
-        string,
-        unknown
-      >;
-    } catch (e) {
-      console.error(
-        "[Settings] Could not parse gallery-dl.conf, resetting to default:",
-        e,
-      );
-    }
-  }
-
-  // If config is empty, read from default template first
-  if (
-    Object.keys(configJson).length === 0 &&
-    existsSync(resolvedDefaultConfigPath)
-  ) {
-    try {
-      configJson = JSON.parse(
+      defaultConfigJson = JSON.parse(
         await fs.readFile(resolvedDefaultConfigPath, "utf-8"),
       ) as Record<string, unknown>;
     } catch (e) {
       console.error("[Settings] Could not parse default template config:", e);
     }
   }
+
+  let existingConfigJson: Record<string, unknown> = {};
+  if (existsSync(configPath)) {
+    try {
+      existingConfigJson = JSON.parse(
+        await fs.readFile(configPath, "utf-8"),
+      ) as Record<string, unknown>;
+    } catch (e) {
+      console.error(
+        "[Settings] Could not parse gallery-dl.conf, using default:",
+        e,
+      );
+    }
+  }
+
+  // Merge existing config on top of the default template config
+  const configJson = deepMerge(defaultConfigJson, existingConfigJson);
 
   // Merge scraper settings into configJson in a type-safe way
   const downloader = (configJson.downloader || {}) as Record<string, unknown>;


### PR DESCRIPTION
# Walkthrough — E-Hentai & ExHentai Support

We have implemented complete support for the E-Hentai and ExHentai platforms. 
This walkthrough details the changes made, the configuration merging strategy, and the integration test results.

## Changes Made

### 1. Database Schema & Migration
- Added the `postDetailsEHentai` table to [schema.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/schema.ts) to store metadata including `gid` (gallery ID), `token`, category, uploader, rating, and file count.
- Generated the schema migration and updated the SQL file [0012_useful_vivisector.sql](file:///home/darkkal/Source/Remote/Github/web-gallery/drizzle/0012_useful_vivisector.sql) to drop and recreate the FTS5 search triggers.
- Trigger changes now index the E-Hentai/ExHentai uploader directly into the FTS search virtual table (`posts_fts`), enabling `user:UploaderName` or `handle:UploaderName` search queries.

### 2. Configuration Synchronization & Safe Merging
- Implemented a recursive `deepMerge` utility in [settings.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/settings.ts) and [runner.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/scrapers/runner.ts).
- Upgraded the scraper config loading logic: `gallery-dl-default.conf` acts as the base template and is recursively merged with the existing `gallery-dl.conf` on boot or settings updates. This pushes new platform configurations safely to production and test environments without discarding user configs (e.g. customized proxies or rate limits).
- Configured E-Hentai and ExHentai in [gallery-dl-default.conf](file:///home/darkkal/Source/Remote/Github/web-gallery/gallery-dl-default.conf) to download galleries into partitioned subdirectories per gallery using `"{category}/{gid}"`.
- Updated the metadata postprocessor's filename pattern to include `gid` (`"{post_id|tweet_id|id|gid|filename}.json"`). This ensures E-Hentai/ExHentai metadata files are named `{gid}.json` (e.g., `123456.json`) instead of `None.json`.

### 3. Library Scanner & Metadata Processor
- Created the dedicated [EHentaiProcessor](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/ehentai.ts) processor.
- Grouping logic: maps each gallery page's metadata to a single database `posts` record keyed by the gallery ID (`gid`). This ensures multiple downloaded image pages of a gallery are grouped together as a single card in gallery and timeline feeds rather than treated as individual posts.
- Registered the processor under the factory switcher in [factory.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/processors/factory.ts).
- Seeded the `"ehentai"` and `"exhentai"` extractor IDs in the database in [scanner.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/library/scanner.ts).
- Implemented a directory-based metadata pairing fallback for `ehentai` and `exhentai` extractors. If a media file does not have a direct file-level match to a JSON file (since pages are typically named `001.jpg`, `002.jpg`), the scanner automatically pairs the file with the single JSON metadata file located in that directory. This ensures all downloaded pages are associated with the main gallery post record.

### 4. Sources, Repositories & UI
- Mapped domains `e-hentai.org` and `exhentai.org` to `ehentai` and `exhentai` extractors in both `addSource()` ([sources.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/repositories/sources.ts)) and `refetchPostData()` ([gallery.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/actions/gallery.ts)).
- Mapped the post extractor type in `getTimelinePosts()` ([posts.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/lib/db/repositories/posts.ts)) and set the author uploader name.
- Added `"ehentai"` and `"exhentai"` to the static search autocomplete list in the [route.ts](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/api/autocomplete/route.ts).
- Styled type badges for E-Hentai and ExHentai cards in [page.module.css](file:///home/darkkal/Source/Remote/Github/web-gallery/src/app/timeline/page.module.css).

---

## Verification & Test Results

### 1. Build Verification
Ran `npm run build` cleanly:
- TypeScript finished in 5.1s
- Compiled successfully with no warnings/errors.

### 2. Integration & Grouping Verification
Created a scratch test suite `scratch/test-ehentai.ts` that verified the following database behavior:
- Created a dummy `exhentai` source.
- Processed page 1 and page 2 metadata for `gid: 123456` under the same source.
- Checked that both pages correctly mapped to the **same database Post ID**.
- Inspected the detail record in `post_details_ehentai` to verify properties match.
- Checked that tags (`artist:cle masahiro`, `female:big breasts`) were registered and associated.

```bash
npx tsx scratch/test-ehentai.ts
# Starting E-Hentai processor integration test...
# Initializing database...
# [DB] Database initialized successfully.
# Created test source with ID: 1
# Processing page 1...
# Processed page 1. Post ID: 1
# Processing page 2...
# Processed page 2. Post ID: 1
# SUCCESS: Both pages correctly grouped under the same post ID: 1
# Detail record in DB: {
#   id: 1,
#   postId: 1,
#   gid: 123456,
#   token: 'abcdef1234',
#   ehCategory: 'Doujinshi',
#   uploader: 'TestUploader',
#   language: null,
#   filecount: null,
#   rating: null,
#   torrentcount: null
# }
# Tags linked to post: 2
# Integration test PASSED successfully!
```
